### PR TITLE
Added feature definitions notifications and shared memory

### DIFF
--- a/exe/ectest.cpp
+++ b/exe/ectest.cpp
@@ -155,7 +155,7 @@ int EvaluateAcpi(
 
     if ( !bRc )
     {
-        printf ( "Error in DeviceIoControl : %d", GetLastError());
+        printf ( "Error in DeviceIoControl : %d\n", GetLastError());
         return ERROR_INVALID_PARAMETER;
     }
 
@@ -275,11 +275,14 @@ exit:
     return status;
 }
 
-
 int GetKMDFNotification(
     _In_ HANDLE hDevice
     )
 {
+#ifndef EC_TEST_NOTIFICATIONS
+    UNREFERENCED_PARAMETER(hDevice);
+    printf("EC_TEST_NOTIFICATIONS not defined.\n");
+#else
     BOOL bRc;
     ULONG bytesReturned;
     NotificationRsp_t notify_response;
@@ -309,14 +312,20 @@ int GetKMDFNotification(
     printf("    timestamp: 0x%llx\n", notify_response.timestamp);
     printf("    lastevent: 0x%x\n", notify_response.lastevent);
 
+#endif // EC_TEST_NOTIFICATIONS
+
     return ERROR_SUCCESS;
 }
-
 
 int ReadRxBuffer(
     _In_ HANDLE hDevice
     )
 {
+#ifndef EC_TEST_SHARED_BUFFER
+    UNREFERENCED_PARAMETER(hDevice);
+    printf("EC_TEST_SHARED_BUFFER not defined.\n");
+#else
+
     BOOL bRc;
     ULONG bytesReturned;
     ULONG inbuf;
@@ -342,6 +351,7 @@ int ReadRxBuffer(
 
     // Print out notification details
     printf("         data: 0x%llx\n", rxrsp.data);
+#endif // EC_TEST_SHARED_BUFFER
 
     return ERROR_SUCCESS;
 }
@@ -373,14 +383,19 @@ main(
     if(status == ERROR_SUCCESS) {
         status = GetKMDFDriverHandle(&hDevice);
         status = EvaluateAcpi(hDevice);
+ 
+#ifdef EC_TEST_NOTIFICATIONS 
         status = GetKMDFNotification(hDevice);
+#endif // EC_TEST_NOTIFICATIONS
+
+#ifdef EC_TEST_SHARED_BUFFER
         status = ReadRxBuffer(hDevice);
+ #endif // EC_TEST_SHARED_BUFFER
+        
         if(hDevice != NULL) {
             CloseHandle(hDevice);
         }
     }
 
-    // Hang out here before we try to terminate
-    Sleep(10000);
     return status;
 }

--- a/kmdf/queue.c
+++ b/kmdf/queue.c
@@ -24,6 +24,8 @@ Abstract:
 #pragma alloc_text (PAGE, ECTestQueueInitialize)
 #endif
 
+
+#ifdef EC_TEST_NOTIFICATIONS
 // Globals
 NotificationRsp_t m_NotifyStats = {0};
 
@@ -91,6 +93,7 @@ NTSTATUS SetupNotification(WDFDEVICE device)
     }
     return status;
 }
+#endif // EC_TEST_NOTIFICATIONS
 
 
 /*
@@ -141,8 +144,10 @@ ECTestQueueInitialize(
         return status;
     }
 
-
+#ifdef EC_TEST_NOTIFICATIONS
     status = SetupNotification(Device);
+#endif // EC_TEST_NOTIFICATIONS
+
     return status;
 }
 
@@ -338,6 +343,8 @@ ECTestEvtIoDeviceControl(
 
         // Request will be completed later in work item callback
         return;
+
+#ifdef EC_TEST_NOTIFICATIONS
     case IOCTL_GET_NOTIFICATION:
         size_t reqSize = 0;
         size_t rspSize = 0;
@@ -360,9 +367,10 @@ ECTestEvtIoDeviceControl(
         rsp->count = m_NotifyStats.count;
         rsp->timestamp = m_NotifyStats.timestamp;
         rsp->lastevent = m_NotifyStats.lastevent;
-
         break;
+#endif // EC_TEST_NOTIFICATIONS
 
+#ifdef EC_TEST_SHARED_BUFFER
     case IOCTL_READ_RX_BUFFER:
         size_t rxSize = 0;
         RxBufferRsp_t *rxrsp = NULL;
@@ -396,8 +404,8 @@ ECTestEvtIoDeviceControl(
         MmUnmapIoSpace(virtualAddress, sizeof(ULONG64));
         
         rxrsp->data = value;
-
         break;
+#endif // EC_TEST_SHARED_BUFFER
 
     default:
         status = STATUS_INVALID_PARAMETER;


### PR DESCRIPTION
Only compile in notification and shared buffer code if features are defined.

This will allow base functionality to work and extra features be enabled as they are supported.