### PR TITLE
ACPI parameter support and cleanup

### DIFF
--- a/exe/ectest.cpp
+++ b/exe/ectest.cpp
@@ -46,6 +46,7 @@ extern "C" {
 //#define EC_TEST_SHARED_BUFFER
 
 #define ACPI_OUTPUT_BUFFER_SIZE 1024
+#define MAX_STRING_LEN 256
 
 // Global event handle
 static HANDLE gExitEvent = NULL;
@@ -63,18 +64,18 @@ static HANDLE gExitEvent = NULL;
  * Return Value:
  * None.
  */
-void DumpAcpi(char *methodName )
+int DumpAcpi(ACPI_EVAL_INPUT_BUFFER_COMPLEX_V1_EX *acpiinput )
 {
 
     BYTE buffer[ACPI_OUTPUT_BUFFER_SIZE];
     ACPI_EVAL_OUTPUT_BUFFER_V1 *AcpiOut = (ACPI_EVAL_OUTPUT_BUFFER_V1 *)buffer;
     size_t buffer_size = sizeof(buffer);
 
-    int status = EvaluateAcpi(methodName, strlen(methodName), buffer, &buffer_size );
+    int status = EvaluateAcpi((void *)acpiinput, sizeof(ACPI_EVAL_INPUT_BUFFER_COMPLEX_V1_EX) + acpiinput->Size, buffer, &buffer_size );
 
     if(status != ERROR_SUCCESS) {
-        printf("EvaluateAcpi failed, status: 0x%x", status);
-        return;
+        printf("EvaluateAcpi failed, status: 0x%x\n", status);
+        return status;
     }
 
     // Print the raw output data returned from ACPI function
@@ -114,6 +115,28 @@ void DumpAcpi(char *methodName )
         printf(" 0x%x",((BYTE *)AcpiOut)[i]);
     }
     printf("\n\n");
+
+    return ERROR_SUCCESS;
+}
+
+/*
+ * Function: BYTE ToHex
+ *
+ * Description:
+ * This function converts an ASCII character to corresponding hex value or returns 0 if invalid
+ *
+ * Parameters:
+ * c: Character to convert
+ *
+ * Return Value:
+ * BYTE value between 0 and 15 if valid; 0 otherwise.
+ */
+BYTE ToHex(char c)
+{
+    if(c >= '0' && c <= '9') return c - '0';
+    if(c >= 'a' && c <= 'f') return (c - 'a' + 10);
+    if(c >= 'A' && c <= 'F') return (c - 'A' + 10);
+    return 0;
 }
 
 /*
@@ -135,16 +158,86 @@ int ParseCmdline(
     _In_ char ** argv
     )
 {
-    if (argc > 2) {
-        DumpAcpi(argv[2]);
-    } else {
+    // Must always have at least 3 parameters
+    if( argc < 3 ) {
         printf("Usage:\n");
         printf("    ectest.exe                        --- Print this help\n");
         printf("    ectest.exe -acpi \\_SB.ECT0.NEVT  --- Evaluate given ACPI method\n");
         return ERROR_INVALID_PARAMETER;
     }
 
-    return ERROR_SUCCESS;
+    BYTE buffer[ACPI_OUTPUT_BUFFER_SIZE];
+    ACPI_EVAL_INPUT_BUFFER_COMPLEX_V1_EX *params = (ACPI_EVAL_INPUT_BUFFER_COMPLEX_V1_EX *)buffer;
+    params->Signature = ACPI_EVAL_INPUT_BUFFER_COMPLEX_SIGNATURE_EX;
+    strncpy_s(params->MethodName,sizeof(params->MethodName),argv[2],strlen(argv[2]) );
+    params->ArgumentCount = argc - 3;
+    params->Size = 0;
+
+    printf("Signature: 0x%x\n", params->Signature);
+
+    // Iterate through the argument creation
+    ACPI_METHOD_ARGUMENT_V1 *arg = &params->Argument[0];
+
+    // Loop through each remaining parameters and convert to correct type
+    for(size_t i=0; i < params->ArgumentCount; i++) {
+        // GUID must be in this exact format {25cb5207-ac36-427d-aaef-3aa78877d27e}
+        if(argv[i+3][0] == '{') {
+            size_t str_len = strlen(argv[i+3]);
+            printf("Converting to GUID len: %i\n", (int)str_len);
+            if(str_len != 38) {
+                printf("Please provide GUID in this format: {25cb5207-ac36-427d-aaef-3aa78877d27e}");
+                return ERROR_INVALID_PARAMETER;
+            }
+
+            arg->Type = ACPI_METHOD_ARGUMENT_BUFFER;
+            arg->DataLength = 16;
+            char *guid_ptr = argv[i+3] + 1;
+            arg->Data[3] = ToHex(guid_ptr[0]) << 4 | ToHex(guid_ptr[1]); guid_ptr+=2;
+            arg->Data[2] = ToHex(guid_ptr[0]) << 4 | ToHex(guid_ptr[1]); guid_ptr+=2;
+            arg->Data[1] = ToHex(guid_ptr[0]) << 4 | ToHex(guid_ptr[1]); guid_ptr+=2;
+            arg->Data[0] = ToHex(guid_ptr[0]) << 4 | ToHex(guid_ptr[1]); guid_ptr+=2;
+            guid_ptr++;
+            arg->Data[5] = ToHex(guid_ptr[0]) << 4 | ToHex(guid_ptr[1]); guid_ptr+=2;
+            arg->Data[4] = ToHex(guid_ptr[0]) << 4 | ToHex(guid_ptr[1]); guid_ptr+=2;
+            guid_ptr++;
+            arg->Data[7] = ToHex(guid_ptr[0]) << 4 | ToHex(guid_ptr[1]); guid_ptr+=2;
+            arg->Data[6] = ToHex(guid_ptr[0]) << 4 | ToHex(guid_ptr[1]); guid_ptr+=2;
+            guid_ptr++;
+            arg->Data[8] = ToHex(guid_ptr[0]) << 4 | ToHex(guid_ptr[1]); guid_ptr+=2;
+            arg->Data[9] = ToHex(guid_ptr[0]) << 4 | ToHex(guid_ptr[1]); guid_ptr+=2;
+            guid_ptr++;
+            arg->Data[10] = ToHex(guid_ptr[0]) << 4 | ToHex(guid_ptr[1]); guid_ptr+=2;
+            arg->Data[11] = ToHex(guid_ptr[0]) << 4 | ToHex(guid_ptr[1]); guid_ptr+=2;
+            arg->Data[12] = ToHex(guid_ptr[0]) << 4 | ToHex(guid_ptr[1]); guid_ptr+=2;
+            arg->Data[13] = ToHex(guid_ptr[0]) << 4 | ToHex(guid_ptr[1]); guid_ptr+=2;
+            arg->Data[14] = ToHex(guid_ptr[0]) << 4 | ToHex(guid_ptr[1]); guid_ptr+=2;
+            arg->Data[15] = ToHex(guid_ptr[0]) << 4 | ToHex(guid_ptr[1]); guid_ptr+=2;
+
+            for(int j=0 ;j < 16; j++) {
+                printf("arg->Data[%i] = 0x%x\n",j,arg->Data[j]);
+            }
+            // Copy the GUID to byte array
+        } else if(argv[i+3][0] == '0') {
+            arg->Type = ACPI_METHOD_ARGUMENT_INTEGER;
+            arg->Argument = static_cast<int>(strtol(argv[i+3], nullptr, 0));
+            arg->DataLength = 4; // Length of DWORD
+            printf("Converting to Number: 0x%x\n",arg->Argument);
+        } else {
+            arg->Type = ACPI_METHOD_ARGUMENT_STRING;
+            arg->DataLength = (USHORT)(strlen(argv[i+3]) + 1);
+            strncpy_s((char *)arg->Data, MAX_STRING_LEN, argv[i+3], arg->DataLength);
+            printf("Converting to String: %s\n", arg->Data);
+        }
+        params->Size += arg->DataLength;
+
+        // Increment to next value
+        arg = (ACPI_METHOD_ARGUMENT_V1 *)((UINT64)arg + sizeof(USHORT)*2 + arg->DataLength);
+    }
+
+    // Evaluate and dump output
+    int status = DumpAcpi(params);
+
+    return status;
 }
 
 /*

--- a/exe/ectest_app.vcxproj
+++ b/exe/ectest_app.vcxproj
@@ -89,7 +89,8 @@
   </PropertyGroup>
   <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Release|x64'">
     <Link>
-      <AdditionalDependencies>%(AdditionalDependencies);mincore.lib</AdditionalDependencies>
+      <AdditionalLibraryDirectories>%(AdditionalLibraryDirectories);..\lib\$(platform)\Release</AdditionalLibraryDirectories>
+      <AdditionalDependencies>%(AdditionalDependencies);mincore.lib;eclib.lib</AdditionalDependencies>
     </Link>
     <ResourceCompile>
       <AdditionalIncludeDirectories>%(AdditionalIncludeDirectories);$(DDK_INC_PATH);$(SDK_INC_PATH)</AdditionalIncludeDirectories>

--- a/inc/eclib.h
+++ b/inc/eclib.h
@@ -32,8 +32,8 @@ ECLIB_API int GetKMDFDriverHandle(
 );
 
 ECLIB_API int EvaluateAcpi(
-    _In_ const char* eval,
-    _In_ size_t eval_len,
+    _In_ void* acpi_input,
+    _In_ size_t input_len,
     _Out_ BYTE* buffer,
     _In_ size_t* buf_len
 );

--- a/lib/eclib.c
+++ b/lib/eclib.c
@@ -161,8 +161,8 @@ int GetKMDFDriverHandle(
  * Description:
  *   Evaluates an ACPI method on a specified device and returns the result.
  * Parameters:
- *   const char* eval     - ACPI method name.
- *   size_t eval_len      - Length of the method name.
+ *   void* acpi_input     - ACPI_EVAL_INPUT_xxxx structure pointer passed through
+ *   size_t input_len     - Length of input structure
  *   BYTE* buffer         - Output buffer for the result.
  *   size_t* buf_len      - Input: size of buffer; Output: bytes returned.
  * Return Value:
@@ -170,22 +170,16 @@ int GetKMDFDriverHandle(
  */
 ECLIB_API
 int EvaluateAcpi(
-    _In_ const char* eval,
-    _In_ size_t eval_len,
+    _In_ void* acpi_input,
+    _In_ size_t input_len,
     _Out_ BYTE* buffer,
     _In_ size_t* buf_len
 )
 {
     WCHAR pathbuf[MAX_DEVPATH_LENGTH];
-    ACPI_EVAL_INPUT_BUFFER_V1_EX InputBuffer = { 0 };
     ULONG bytesReturned;
 
-    memset(buffer, 0, *buf_len);
-    InputBuffer.Signature = ACPI_EVAL_INPUT_BUFFER_SIGNATURE_EX;
-    strncpy_s(InputBuffer.MethodName, sizeof(InputBuffer.MethodName), eval, eval_len);
-
     // Look up handle to ACPI entry
-
     wchar_t* dpath = GetGUIDPath(GUID_DEVCLASS_ECTEST, L"ETST0001", pathbuf, sizeof(pathbuf));
     if (dpath == NULL) {
         return ERROR_INVALID_PARAMETER;
@@ -202,8 +196,8 @@ int EvaluateAcpi(
     if (hDevice != INVALID_HANDLE_VALUE) {
         if( DeviceIoControl(hDevice,
             (DWORD)IOCTL_ACPI_EVAL_METHOD_EX,
-            &InputBuffer,
-            sizeof(InputBuffer),
+            acpi_input,
+            (DWORD)input_len,
             buffer,
             (DWORD)*buf_len,
             &bytesReturned,

--- a/rust/src/battery.rs
+++ b/rust/src/battery.rs
@@ -107,7 +107,7 @@ impl Battery {
         let bat_status = Self::get_bst();
         //let bat_info = Self::get_bix();
         //let bat_percent = (bat_status.capacity / bat_info.design_capacity) * 100;
-        let bat_percent = bat_status.capacity / 120; // Use fake values till BIX is available
+        let bat_percent = bat_status.capacity / 82; // Use fake values till BIX is available
 
         let status_title = Self::title_block("Battery Status");
         Paragraph::new(Self::create_status(area, bat_status))
@@ -149,7 +149,7 @@ impl Battery {
     }
     */
 
-    fn title_block(title: &str) -> Block {
+    fn title_block(title: &str) -> Block<'_> {
         let title = Line::from(title);
         Block::new()
             .borders(Borders::NONE)
@@ -161,8 +161,8 @@ impl Battery {
     fn create_status(_area: Rect, status: BstData) -> Vec<Line<'static>> {
         vec![
             Line::raw(format!("State:               {:?}", status.state)),
-            Line::raw(format!("Present Rate:        {:?}mAh", status.rate)),
-            Line::raw(format!("Remaining Capacity:  {:?}mAh", status.capacity)),
+            Line::raw(format!("Present Rate:        {:?}mWh", status.rate)),
+            Line::raw(format!("Remaining Capacity:  {:?}mWh", status.capacity)),
             Line::raw(format!("Present Voltage:     {:?}mV", status.voltage)),
         ]
     }

--- a/rust/src/main.rs
+++ b/rust/src/main.rs
@@ -27,8 +27,7 @@ use strum::{Display, EnumIter, FromRepr, IntoEnumIterator};
 fn main() -> Result<()> {
     color_eyre::install()?;
     let terminal = ratatui::init();
-    let app_result = App::default().run(terminal);
-    app_result
+    App::default().run(terminal)
 }
 
 /// The main application which holds the state and logic of the application.

--- a/rust/src/rtc.rs
+++ b/rust/src/rtc.rs
@@ -18,7 +18,7 @@ impl Rtc {
     }
 }
 
-fn title_block(title: &str) -> Block {
+fn title_block(title: &str) -> Block<'_> {
     let title = Line::from(title);
     Block::new()
         .borders(Borders::NONE)

--- a/rust/src/thermal.rs
+++ b/rust/src/thermal.rs
@@ -18,7 +18,7 @@ impl Thermal {
     }
 }
 
-fn title_block(title: &str) -> Block {
+fn title_block(title: &str) -> Block<'_> {
     let title = Line::from(title);
     Block::new()
         .borders(Borders::NONE)

--- a/rust/src/ucsi.rs
+++ b/rust/src/ucsi.rs
@@ -18,7 +18,7 @@ impl Ucsi {
     }
 }
 
-fn title_block(title: &str) -> Block {
+fn title_block(title: &str) -> Block<'_> {
     let title = Line::from(title);
     Block::new()
         .borders(Borders::NONE)


### PR DESCRIPTION
Add support to pass ACPI input parameters down to KMDF driver from both rust application and the test app.
Clean up some clippy warnings.
Validated functionality of both ectest.exe, ectest.sys and ec_demo.exe on target device.