### PR TITLE
Implement fan get/set var support

### DIFF
--- a/rust/src/acpi.rs
+++ b/rust/src/acpi.rs
@@ -88,7 +88,7 @@ pub const ACPI_EVAL_INPUT_BUFFER_COMPLEX_SIGNATURE_EX: u32 = u32::from_le_bytes(
 
 impl std::fmt::Display for AcpiParseError {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
-        write!(f, "{:?}", self)
+        write!(f, "{self:?}")
     }
 }
 

--- a/rust/src/battery.rs
+++ b/rust/src/battery.rs
@@ -138,7 +138,7 @@ impl Battery {
         let result = Acpi::evaluate("\\_SB.ECT0.TBST", None);
         match result {
             Ok(value) => value.into(),
-            Err(e) => panic!("Failed {}", e),
+            Err(e) => panic!("Failed {e}"),
         }
     }
 


### PR DESCRIPTION
This PR implements fan ACPI get/set var support in the thermal tab, now allowing for user to set the fan RPM to a specific value (the below screenshot shows actual fan response as I changed the RPM manually). Will update again for sensor get/set var and sensor get/set thrs once I get that supported in the ACPI tables.

Also, second commit just to cleanup a few clippy warnings I noticed.

<img width="2350" height="1286" alt="thermal" src="https://github.com/user-attachments/assets/8a44df0c-3d8e-429d-aaef-50f5771818d7" />
