### PR TITLE
Refactor modules

### DIFF
--- a/rust/src/battery.rs
+++ b/rust/src/battery.rs
@@ -1,6 +1,8 @@
+use crate::Module;
 #[cfg(not(feature = "mock"))]
 use crate::acpi::{Acpi, AcpiEvalOutputBufferV1};
 
+use crossterm::event::Event;
 use ratatui::{
     buffer::Buffer,
     layout::Rect,
@@ -51,6 +53,40 @@ pub struct BixData {
 
 #[derive(Default)]
 pub struct Battery {}
+
+impl Module for Battery {
+    fn update(&mut self) {}
+
+    fn handle_event(&mut self, _evt: &Event) {}
+
+    fn render(&self, area: Rect, buf: &mut Buffer) {
+        let bat_status = Self::get_bst();
+        //let bat_info = Self::get_bix();
+        //let bat_percent = (bat_status.capacity / bat_info.design_capacity) * 100;
+        let bat_percent = bat_status.capacity / 82; // Use fake values till BIX is available
+
+        let status_title = Self::title_block("Battery Status");
+        Paragraph::new(Self::create_status(area, bat_status))
+            .block(status_title)
+            .render(area, buf);
+
+        /*
+        let info_title = Self::title_block("Battery Info");
+        let bix_area = Rect::new(area.x, area.y + 6, area.width / 2, 4);
+        Paragraph::new(Self::create_info(bix_area,bat_info))
+            .block(info_title)
+            .render(bix_area, buf);
+        */
+
+        let gauge_area = Rect::new(area.x, area.y + 20, area.width / 2, 4);
+        let title = Self::title_block("Battery Percentage:");
+        Gauge::default()
+            .block(title)
+            .gauge_style(BATGAUGE_COLOR)
+            .percent(bat_percent.try_into().unwrap())
+            .render(gauge_area, buf);
+    }
+}
 
 // Convert ACPI result to BstData
 #[cfg(not(feature = "mock"))]
@@ -105,32 +141,8 @@ impl From<AcpiEvalOutputBufferV1> for BixData {
 */
 
 impl Battery {
-    pub fn render(area: Rect, buf: &mut Buffer) {
-        let bat_status = Self::get_bst();
-        //let bat_info = Self::get_bix();
-        //let bat_percent = (bat_status.capacity / bat_info.design_capacity) * 100;
-        let bat_percent = bat_status.capacity / 82; // Use fake values till BIX is available
-
-        let status_title = Self::title_block("Battery Status");
-        Paragraph::new(Self::create_status(area, bat_status))
-            .block(status_title)
-            .render(area, buf);
-
-        /*
-        let info_title = Self::title_block("Battery Info");
-        let bix_area = Rect::new(area.x, area.y + 6, area.width / 2, 4);
-        Paragraph::new(Self::create_info(bix_area,bat_info))
-            .block(info_title)
-            .render(bix_area, buf);
-        */
-
-        let gauge_area = Rect::new(area.x, area.y + 20, area.width / 2, 4);
-        let title = Self::title_block("Battery Percentage:");
-        Gauge::default()
-            .block(title)
-            .gauge_style(BATGAUGE_COLOR)
-            .percent(bat_percent.try_into().unwrap())
-            .render(gauge_area, buf);
+    pub fn new() -> Self {
+        Self {}
     }
 
     #[cfg(not(feature = "mock"))]

--- a/rust/src/battery.rs
+++ b/rust/src/battery.rs
@@ -55,6 +55,10 @@ pub struct BixData {
 pub struct Battery {}
 
 impl Module for Battery {
+    fn title(&self) -> &'static str {
+        "Battery Information"
+    }
+
     fn update(&mut self) {}
 
     fn handle_event(&mut self, _evt: &Event) {}

--- a/rust/src/main.rs
+++ b/rust/src/main.rs
@@ -25,7 +25,10 @@ use ratatui::{
 
 use strum::{Display, EnumIter, FromRepr, IntoEnumIterator};
 
-use std::time::{Duration, Instant};
+use std::{
+    collections::BTreeMap,
+    time::{Duration, Instant},
+};
 
 fn main() -> Result<()> {
     color_eyre::install()?;
@@ -34,12 +37,39 @@ fn main() -> Result<()> {
 }
 
 /// The main application which holds the state and logic of the application.
-#[derive(Default)]
 pub struct App {
     state: AppState,
     selected_tab: SelectedTab,
-    thermal: Thermal,
-    // TODO: Add fields for other services as they are implemented
+    modules: BTreeMap<SelectedTab, Box<dyn Module>>,
+}
+
+impl Default for App {
+    fn default() -> Self {
+        let mut modules: BTreeMap<SelectedTab, Box<dyn Module>> = BTreeMap::new();
+
+        modules.insert(SelectedTab::TabThermal, Box::new(Thermal::new()));
+        modules.insert(SelectedTab::TabRTC, Box::new(Rtc::new()));
+        modules.insert(SelectedTab::TabUCSI, Box::new(Ucsi::new()));
+        modules.insert(SelectedTab::TabBattery, Box::new(Battery::new()));
+
+        Self {
+            state: Default::default(),
+            selected_tab: Default::default(),
+            modules,
+        }
+    }
+}
+
+/// Internal trait to be implemented by modules (or Tabs).
+pub(crate) trait Module {
+    /// Update the module.
+    fn update(&mut self);
+
+    /// Handle input event.
+    fn handle_event(&mut self, evt: &Event);
+
+    /// Render the module.
+    fn render(&self, area: Rect, buf: &mut Buffer);
 }
 
 #[derive(Default, Clone, Copy, PartialEq, Eq)]
@@ -49,7 +79,7 @@ enum AppState {
     Quitting,
 }
 
-#[derive(Default, Clone, Copy, Display, FromRepr, EnumIter)]
+#[derive(Default, Clone, Copy, Display, FromRepr, EnumIter, PartialEq, Eq, PartialOrd, Ord, Hash)]
 enum SelectedTab {
     #[default]
     #[strum(to_string = "Battery")]
@@ -113,18 +143,16 @@ impl App {
     }
 
     fn handle_tab_event(&mut self, evt: &Event) {
-        // TODO: Handle input for other tabs as they are implemented
-        match self.selected_tab {
-            SelectedTab::TabThermal => self.thermal.handle_event(evt),
-            SelectedTab::TabBattery => {}
-            SelectedTab::TabRTC => {}
-            SelectedTab::TabUCSI => {}
-        }
+        self.modules
+            .get_mut(&self.selected_tab)
+            .expect("Tab must exist")
+            .handle_event(evt);
     }
 
     fn update_tabs(&mut self) {
-        // TODO: Update other tabs as they are implemented
-        self.thermal.update();
+        for module in self.modules.values_mut() {
+            module.update();
+        }
     }
 
     pub fn next_tab(&mut self) {
@@ -205,7 +233,10 @@ impl App {
         let inner = block.inner(area);
 
         block.render(area, buf);
-        Battery::render(inner, buf);
+        self.modules
+            .get(&self.selected_tab)
+            .expect("Battery must exist")
+            .render(inner, buf);
     }
 
     fn render_thermal(&self, area: Rect, buf: &mut Buffer) {
@@ -213,7 +244,10 @@ impl App {
         let inner = block.inner(area);
 
         block.render(area, buf);
-        self.thermal.render(inner, buf);
+        self.modules
+            .get(&SelectedTab::TabThermal)
+            .expect("Thermal must exist")
+            .render(inner, buf);
     }
 
     fn render_rtc(&self, area: Rect, buf: &mut Buffer) {
@@ -221,7 +255,10 @@ impl App {
         let inner = block.inner(area);
 
         block.render(area, buf);
-        Rtc::render(inner, buf);
+        self.modules
+            .get(&self.selected_tab)
+            .expect("RTC must exist")
+            .render(inner, buf);
     }
 
     fn render_ucsi(&self, area: Rect, buf: &mut Buffer) {
@@ -229,7 +266,10 @@ impl App {
         let inner = block.inner(area);
 
         block.render(area, buf);
-        Ucsi::render(inner, buf);
+        self.modules
+            .get(&self.selected_tab)
+            .expect("UCSI must exist")
+            .render(inner, buf);
     }
 }
 

--- a/rust/src/main.rs
+++ b/rust/src/main.rs
@@ -62,6 +62,9 @@ impl Default for App {
 
 /// Internal trait to be implemented by modules (or Tabs).
 pub(crate) trait Module {
+    /// The module's title.
+    fn title(&self) -> &'static str;
+
     /// Update the module.
     fn update(&mut self);
 
@@ -220,56 +223,12 @@ impl App {
     }
 
     fn render_selected_tab(&self, area: Rect, buf: &mut Buffer) {
-        match self.selected_tab {
-            SelectedTab::TabBattery => self.render_battery(area, buf),
-            SelectedTab::TabThermal => self.render_thermal(area, buf),
-            SelectedTab::TabRTC => self.render_rtc(area, buf),
-            SelectedTab::TabUCSI => self.render_ucsi(area, buf),
-        }
-    }
-
-    fn render_battery(&self, area: Rect, buf: &mut Buffer) {
-        let block = self.selected_tab.block().title("Battery Information");
+        let module = self.modules.get(&self.selected_tab).expect("Tab must exist");
+        let block = self.selected_tab.block().title(module.title());
         let inner = block.inner(area);
 
         block.render(area, buf);
-        self.modules
-            .get(&self.selected_tab)
-            .expect("Battery must exist")
-            .render(inner, buf);
-    }
-
-    fn render_thermal(&self, area: Rect, buf: &mut Buffer) {
-        let block = self.selected_tab.block().title("Thermal Information");
-        let inner = block.inner(area);
-
-        block.render(area, buf);
-        self.modules
-            .get(&SelectedTab::TabThermal)
-            .expect("Thermal must exist")
-            .render(inner, buf);
-    }
-
-    fn render_rtc(&self, area: Rect, buf: &mut Buffer) {
-        let block = self.selected_tab.block().title("RTC Information");
-        let inner = block.inner(area);
-
-        block.render(area, buf);
-        self.modules
-            .get(&self.selected_tab)
-            .expect("RTC must exist")
-            .render(inner, buf);
-    }
-
-    fn render_ucsi(&self, area: Rect, buf: &mut Buffer) {
-        let block = self.selected_tab.block().title("UCSI Information");
-        let inner = block.inner(area);
-
-        block.render(area, buf);
-        self.modules
-            .get(&self.selected_tab)
-            .expect("UCSI must exist")
-            .render(inner, buf);
+        module.render(inner, buf);
     }
 }
 

--- a/rust/src/rtc.rs
+++ b/rust/src/rtc.rs
@@ -1,3 +1,4 @@
+use crossterm::event::Event;
 use ratatui::{
     buffer::Buffer,
     layout::Rect,
@@ -6,15 +7,27 @@ use ratatui::{
     widgets::{Block, Borders, Padding, Paragraph, Widget},
 };
 
+use crate::Module;
+
 const LABEL_COLOR: Color = tailwind::SLATE.c200;
 
 #[derive(Default)]
 pub struct Rtc {}
 
-impl Rtc {
-    pub fn render(area: Rect, buf: &mut Buffer) {
+impl Module for Rtc {
+    fn update(&mut self) {}
+
+    fn handle_event(&mut self, _evt: &Event) {}
+
+    fn render(&self, area: Rect, buf: &mut Buffer) {
         let status_title = title_block("RTC Properties");
         Paragraph::default().block(status_title).render(area, buf);
+    }
+}
+
+impl Rtc {
+    pub fn new() -> Self {
+        Self {}
     }
 }
 

--- a/rust/src/rtc.rs
+++ b/rust/src/rtc.rs
@@ -15,6 +15,10 @@ const LABEL_COLOR: Color = tailwind::SLATE.c200;
 pub struct Rtc {}
 
 impl Module for Rtc {
+    fn title(&self) -> &'static str {
+        "RTC Information"
+    }
+
     fn update(&mut self) {}
 
     fn handle_event(&mut self, _evt: &Event) {}

--- a/rust/src/thermal.rs
+++ b/rust/src/thermal.rs
@@ -1,3 +1,4 @@
+use crate::Module;
 #[cfg(not(feature = "mock"))]
 use crate::acpi::{Acpi, AcpiMethodArgument};
 
@@ -307,14 +308,20 @@ pub struct Thermal {
     t: usize,
 }
 
-impl Thermal {
-    pub fn update(&mut self) {
+impl Module for Thermal {
+    fn update(&mut self) {
         self.sensor.update();
         self.fan.update();
         self.t += 1;
     }
 
-    pub fn handle_event(&mut self, evt: &Event) {
+    fn render(&self, area: Rect, buf: &mut Buffer) {
+        let [sensor_area, fan_area] = area_split(area, Direction::Horizontal, 50, 50);
+        self.render_sensor(sensor_area, buf);
+        self.render_fan(fan_area, buf);
+    }
+
+    fn handle_event(&mut self, evt: &Event) {
         if let Event::Key(key) = evt
             && key.code == KeyCode::Enter
             && key.kind == KeyEventKind::Press
@@ -326,11 +333,11 @@ impl Thermal {
             let _ = self.rpm_input.handle_event(evt);
         }
     }
+}
 
-    pub fn render(&self, area: Rect, buf: &mut Buffer) {
-        let [sensor_area, fan_area] = area_split(area, Direction::Horizontal, 50, 50);
-        self.render_sensor(sensor_area, buf);
-        self.render_fan(fan_area, buf);
+impl Thermal {
+    pub fn new() -> Self {
+        Default::default()
     }
 
     fn render_sensor(&self, area: Rect, buf: &mut Buffer) {

--- a/rust/src/thermal.rs
+++ b/rust/src/thermal.rs
@@ -309,6 +309,10 @@ pub struct Thermal {
 }
 
 impl Module for Thermal {
+    fn title(&self) -> &'static str {
+        "Thermal Information"
+    }
+
     fn update(&mut self) {
         self.sensor.update();
         self.fan.update();

--- a/rust/src/ucsi.rs
+++ b/rust/src/ucsi.rs
@@ -15,6 +15,10 @@ const LABEL_COLOR: Color = tailwind::SLATE.c200;
 pub struct Ucsi {}
 
 impl Module for Ucsi {
+    fn title(&self) -> &'static str {
+        "UCSI Information"
+    }
+
     fn update(&mut self) {}
 
     fn handle_event(&mut self, _evt: &Event) {}

--- a/rust/src/ucsi.rs
+++ b/rust/src/ucsi.rs
@@ -1,3 +1,4 @@
+use crossterm::event::Event;
 use ratatui::{
     buffer::Buffer,
     layout::Rect,
@@ -6,15 +7,27 @@ use ratatui::{
     widgets::{Block, Borders, Padding, Paragraph, Widget},
 };
 
+use crate::Module;
+
 const LABEL_COLOR: Color = tailwind::SLATE.c200;
 
 #[derive(Default)]
 pub struct Ucsi {}
 
-impl Ucsi {
-    pub fn render(area: Rect, buf: &mut Buffer) {
+impl Module for Ucsi {
+    fn update(&mut self) {}
+
+    fn handle_event(&mut self, _evt: &Event) {}
+
+    fn render(&self, area: Rect, buf: &mut Buffer) {
         let status_title = title_block("UCSI State");
         Paragraph::default().block(status_title).render(area, buf);
+    }
+}
+
+impl Ucsi {
+    pub fn new() -> Self {
+        Self {}
     }
 }
 


### PR DESCRIPTION
Refactor modules to simplify the process of adding new modules. Further refactoring is still possible, for example, producing a `Result` instead of calling `expect()`, however that is a slightly more invasive change and should be done as a separate PR.