### PR TITLE
Implement battery tab

### DIFF
--- a/rust/src/app.rs
+++ b/rust/src/app.rs
@@ -76,6 +76,7 @@ impl<S: Source + Clone + 'static> App<S> {
         let source = Rc::new(RefCell::new(source));
 
         let thermal_source = Rc::clone(&source);
+        let battery_source = Rc::clone(&source);
 
         modules.insert(
             SelectedTab::TabThermal,
@@ -83,7 +84,10 @@ impl<S: Source + Clone + 'static> App<S> {
         );
         modules.insert(SelectedTab::TabRTC, Box::new(Rtc::new()));
         modules.insert(SelectedTab::TabUCSI, Box::new(Ucsi::new()));
-        modules.insert(SelectedTab::TabBattery, Box::new(Battery::new()));
+        modules.insert(
+            SelectedTab::TabBattery,
+            Box::new(Battery::new(battery_source.borrow().clone())),
+        );
 
         Self {
             state: Default::default(),

--- a/rust/src/battery.rs
+++ b/rust/src/battery.rs
@@ -1,217 +1,561 @@
-#[cfg(not(feature = "mock"))]
-use crate::acpi::{Acpi, AcpiEvalOutputBufferV1};
+use crate::Source;
 use crate::app::Module;
+use crate::common;
+use color_eyre::{Report, Result, eyre::eyre};
 
-use crossterm::event::Event;
 use ratatui::{
     buffer::Buffer,
-    layout::Rect,
-    style::{Color, Stylize, palette::tailwind},
-    text::Line,
-    widgets::{Block, Borders, Gauge, Padding, Paragraph, Widget},
+    crossterm::event::{Event, KeyCode, KeyEventKind},
+    layout::{Direction, Rect},
+    style::{Color, Style, Stylize, palette::tailwind},
+    text::{Line, Span},
+    widgets::{Bar, BarChart, BarGroup, Block, BorderType, Borders, Paragraph, Widget},
 };
+use tui_input::{Input, backend::crossterm::EventHandler};
 
 const BATGAUGE_COLOR_HIGH: Color = tailwind::GREEN.c500;
 const BATGAUGE_COLOR_MEDIUM: Color = tailwind::YELLOW.c500;
 const BATGAUGE_COLOR_LOW: Color = tailwind::RED.c500;
-
 const LABEL_COLOR: Color = tailwind::SLATE.c200;
+const MAX_SAMPLES: usize = 60;
+
+#[derive(Debug, Clone, Copy, PartialEq, Default)]
+pub enum ChargeState {
+    #[default]
+    Charging,
+    Discharging,
+}
+
+impl TryFrom<u32> for ChargeState {
+    type Error = Report;
+    fn try_from(value: u32) -> Result<Self> {
+        match value {
+            1 => Ok(Self::Discharging),
+            2 => Ok(Self::Charging),
+            _ => Err(eyre!("Unknown charging state")),
+        }
+    }
+}
+
+impl ChargeState {
+    fn as_str(&self) -> &'static str {
+        match self {
+            Self::Charging => "Charging",
+            Self::Discharging => "Discharging",
+        }
+    }
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Default)]
+pub enum PowerUnit {
+    #[default]
+    Mw,
+    Ma,
+}
+
+impl TryFrom<u32> for PowerUnit {
+    type Error = Report;
+    fn try_from(value: u32) -> Result<Self> {
+        match value {
+            0 => Ok(Self::Mw),
+            1 => Ok(Self::Ma),
+            _ => Err(eyre!("Unknown power unit")),
+        }
+    }
+}
+
+impl PowerUnit {
+    fn as_capacity_str(&self) -> &'static str {
+        match self {
+            Self::Mw => "mWh",
+            Self::Ma => "mAh",
+        }
+    }
+
+    fn as_rate_str(&self) -> &'static str {
+        match self {
+            Self::Mw => "mW",
+            Self::Ma => "mA",
+        }
+    }
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Default)]
+pub enum BatteryTechnology {
+    #[default]
+    Primary,
+    Secondary,
+}
+
+impl TryFrom<u32> for BatteryTechnology {
+    type Error = Report;
+    fn try_from(value: u32) -> Result<Self> {
+        match value {
+            0 => Ok(Self::Primary),
+            1 => Ok(Self::Secondary),
+            _ => Err(eyre!("Unknown battery technology")),
+        }
+    }
+}
+
+impl BatteryTechnology {
+    fn as_str(&self) -> &'static str {
+        match self {
+            Self::Primary => "Primary",
+            Self::Secondary => "Secondary",
+        }
+    }
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Default)]
+pub enum SwapCap {
+    #[default]
+    NonSwappable,
+    ColdSwappable,
+    HotSwappable,
+}
+
+impl TryFrom<u32> for SwapCap {
+    type Error = Report;
+    fn try_from(value: u32) -> Result<Self> {
+        match value {
+            0 => Ok(Self::NonSwappable),
+            1 => Ok(Self::ColdSwappable),
+            2 => Ok(Self::HotSwappable),
+            _ => Err(eyre!("Unknown swapping capability")),
+        }
+    }
+}
+
+impl SwapCap {
+    fn as_str(&self) -> &'static str {
+        match self {
+            Self::NonSwappable => "Non swappable",
+            Self::ColdSwappable => "Cold swappable",
+            Self::HotSwappable => "Hot swappable",
+        }
+    }
+}
 
 /// BST: ACPI Battery Status
 #[derive(Default)]
 pub struct BstData {
-    state: u32,
-    rate: u32,
-    capacity: u32,
-    voltage: u32,
+    pub state: ChargeState,
+    pub rate: u32,
+    pub capacity: u32,
+    pub voltage: u32,
 }
 
-/*
-/// BIX: ACPI Battery Informatino eXtended
+/// BIX: ACPI Battery Information eXtended
 #[derive(Default)]
 pub struct BixData {
-    revision: u32,
-    power_unit: u32,    // 0 - mW, 1 - mA
-    design_capacity: u32,
-    last_full_capacity: u32,
-    battery_technology: u32, // 0 - primary, 1 - secondary
-    design_voltage: u32,
-    warning_capacity: u32,
-    low_capacity: u32,
-    cycle_count: u32,
-    accuracy: u32,  // Thousands of a percent
-    max_sample_time: u32,
-    min_sample_time: u32,   // Milliseconds
-    max_average_interval: u32,
-    min_average_internal: u32,
-    capacity_gran1: u32,
-    capacity_gran2: u32,
-    model_number: Vec<u8>,
-    serial_number: Vec<u8>,
-    battery_type: Vec<u8>,
-    oem_info: Vec<u8>,
-    swap_cap: u32,
+    pub revision: u32,
+    pub power_unit: PowerUnit, // 0 - mW, 1 - mA
+    pub design_capacity: u32,
+    pub last_full_capacity: u32,
+    pub battery_technology: BatteryTechnology, // 0 - primary, 1 - secondary
+    pub design_voltage: u32,
+    pub warning_capacity: u32,
+    pub low_capacity: u32,
+    pub cycle_count: u32,
+    pub accuracy: u32, // Thousands of a percent
+    pub max_sample_time: u32,
+    pub min_sample_time: u32, // Milliseconds
+    pub max_average_interval: u32,
+    pub min_average_interval: u32,
+    pub capacity_gran1: u32,
+    pub capacity_gran2: u32,
+    pub model_number: Vec<u8>,
+    pub serial_number: Vec<u8>,
+    pub battery_type: Vec<u8>,
+    pub oem_info: Vec<u8>,
+    pub swap_cap: SwapCap,
 }
-*/
+
+struct BatteryState {
+    btp: u32,
+    btp_input: Input,
+    bst_success: bool,
+    bix_success: bool,
+    btp_success: bool,
+    samples: common::SampleBuf<u32, MAX_SAMPLES>,
+}
+
+impl Default for BatteryState {
+    fn default() -> Self {
+        Self {
+            btp: 0,
+            btp_input: Input::default(),
+            bst_success: false,
+            bix_success: false,
+            btp_success: true,
+            samples: common::SampleBuf::default(),
+        }
+    }
+}
 
 #[derive(Default)]
-pub struct Battery {}
+pub struct Battery<S: Source> {
+    bst_data: BstData,
+    bix_data: BixData,
+    state: BatteryState,
+    t_sec: usize,
+    t_min: usize,
+    source: S,
+}
 
-impl Module for Battery {
+impl<S: Source> Module for Battery<S> {
     fn title(&self) -> &'static str {
         "Battery Information"
     }
 
-    fn update(&mut self) {}
+    fn update(&mut self) {
+        if let Ok(bst_data) = self.source.get_bst() {
+            self.bst_data = bst_data;
+            self.state.bst_success = true;
+        } else {
+            self.state.bst_success = false;
+        }
 
-    fn handle_event(&mut self, _evt: &Event) {}
+        // In mock demo, update graph every second, but real-life update every minute
+        #[cfg(feature = "mock")]
+        let update_graph = true;
+        #[cfg(not(feature = "mock"))]
+        let update_graph = (self.t_sec % 60) == 0;
+
+        self.t_sec += 1;
+        if update_graph {
+            self.state.samples.insert(self.bst_data.capacity);
+            self.t_min += 1;
+        }
+    }
 
     fn render(&self, area: Rect, buf: &mut Buffer) {
-        let bat_status = Self::get_bst();
-        //let bat_info = Self::get_bix();
-        //let bat_percent = (bat_status.capacity / bat_info.design_capacity) * 100;
-        let bat_percent = bat_status.capacity / 82; // Use fake values till BIX is available
-
-        let status_title = Self::title_block("Battery Status");
-        Paragraph::new(Self::create_status(area, bat_status))
-            .block(status_title)
-            .render(area, buf);
-
-        /*
-        let info_title = Self::title_block("Battery Info");
-        let bix_area = Rect::new(area.x, area.y + 6, area.width / 2, 4);
-        Paragraph::new(Self::create_info(bix_area,bat_info))
-            .block(info_title)
-            .render(bix_area, buf);
-        */
-
-        let gauge_area = Rect::new(area.x, area.y + 20, area.width / 2, 4);
-        let title = Self::title_block("Battery Percentage:");
-        Gauge::default()
-            .block(title)
-            .gauge_style(match bat_percent {
-                0..=20 => BATGAUGE_COLOR_LOW,
-                21..=60 => BATGAUGE_COLOR_MEDIUM,
-                _ => BATGAUGE_COLOR_HIGH,
-            })
-            .percent(bat_percent.try_into().unwrap())
-            .use_unicode(true)
-            .render(gauge_area, buf);
+        let [info_area, charge_area] = common::area_split(area, Direction::Horizontal, 80, 20);
+        self.render_info(info_area, buf);
+        self.render_battery(charge_area, buf);
     }
-}
 
-// Convert ACPI result to BstData
-#[cfg(not(feature = "mock"))]
-impl From<AcpiEvalOutputBufferV1> for BstData {
-    fn from(data: AcpiEvalOutputBufferV1) -> Self {
-        // We are expecting 4 32-bit values
-        if data.count != 4 {
-            panic!("Unexpected Count {}", data.count)
-        }
-        BstData {
-            state: data.arguments[0].data_32,
-            rate: data.arguments[1].data_32,
-            capacity: data.arguments[2].data_32,
-            voltage: data.arguments[3].data_32,
+    fn handle_event(&mut self, evt: &Event) {
+        if let Event::Key(key) = evt
+            && key.code == KeyCode::Enter
+            && key.kind == KeyEventKind::Press
+        {
+            if let Ok(btp) = self.state.btp_input.value_and_reset().parse() {
+                if self.source.set_btp(btp).is_ok() {
+                    self.state.btp = btp;
+                    self.state.btp_success = true;
+                } else {
+                    self.state.btp_success = false;
+                }
+            }
+        } else {
+            let _ = self.state.btp_input.handle_event(evt);
         }
     }
 }
 
-// Convert ACPI result to BixData
-/*
-impl From<AcpiEvalOutputBufferV1> for BixData {
-    fn from(data: AcpiEvalOutputBufferV1) -> Self {
-        // We are expecting 21 arguments
-        if data.count != 21 {
-            panic!("Unexpected Count {}", data.count)
+impl<S: Source> Battery<S> {
+    pub fn new(source: S) -> Self {
+        let mut inst = Self {
+            bst_data: Default::default(),
+            bix_data: Default::default(),
+            state: Default::default(),
+            t_sec: Default::default(),
+            t_min: Default::default(),
+            source,
+        };
+
+        // This shouldn't change because BIX info is static so just read once
+        if let Ok(bix_data) = inst.source.get_bix() {
+            inst.bix_data = bix_data;
+            inst.state.bix_success = true;
+        } else {
+            inst.state.bix_success = false;
         }
-        BixData {
-            revision: data.arguments[0].data_32,
-            power_unit: data.arguments[1].data_32,
-            design_capacity: data.arguments[2].data_32,
-            last_full_capacity: data.arguments[3].data_32,
-            battery_technology: data.arguments[4].data_32,
-            design_voltage: data.arguments[5].data_32,
-            warning_capacity: data.arguments[6].data_32,
-            low_capacity: data.arguments[7].data_32,
-            cycle_count: data.arguments[8].data_32,
-            accuracy: data.arguments[9].data_32,
-            max_sample_time: data.arguments[10].data_32,
-            min_sample_time: data.arguments[11].data_32,
-            max_average_interval: data.arguments[12].data_32,
-            min_average_internal: data.arguments[13].data_32,
-            capacity_gran1: data.arguments[14].data_32,
-            capacity_gran2: data.arguments[15].data_32,
-            model_number: data.arguments[16].data.clone(),
-            serial_number: data.arguments[17].data.clone(),
-            battery_type: data.arguments[18].data.clone(),
-            oem_info: data.arguments[19].data.clone(),
-            swap_cap: data.arguments[20].data_32,
-        }
-    }
-}
-*/
 
-impl Battery {
-    pub fn new() -> Self {
-        Self {}
+        inst.update();
+        inst
     }
 
-    #[cfg(not(feature = "mock"))]
-    fn get_bst() -> BstData {
-        let result = Acpi::evaluate("\\_SB.ECT0.TBST", None);
-        match result {
-            Ok(value) => value.into(),
-            Err(e) => panic!("Failed {e}"),
-        }
+    fn render_info(&self, area: Rect, buf: &mut Buffer) {
+        let [bix_area, status_area] = common::area_split(area, Direction::Horizontal, 50, 50);
+        let [bst_area, btp_area] = common::area_split(status_area, Direction::Vertical, 70, 30);
+        let [bst_chart_area, bst_info_area] = common::area_split(bst_area, Direction::Vertical, 65, 35);
+
+        self.render_bix(bix_area, buf);
+        self.render_bst(bst_info_area, buf);
+        self.render_bst_chart(bst_chart_area, buf);
+        self.render_btp(btp_area, buf);
     }
 
-    #[cfg(feature = "mock")]
-    fn get_bst() -> BstData {
-        BstData {
-            state: 2,
-            rate: 3839,
-            capacity: 5574,
-            voltage: 12569,
-        }
+    fn render_bst_chart(&self, area: Rect, buf: &mut Buffer) {
+        let y_labels = [
+            "0".bold(),
+            Span::styled(
+                format!("{}", self.bix_data.design_capacity / 2),
+                Style::default().bold(),
+            ),
+            Span::styled(format!("{}", self.bix_data.design_capacity), Style::default().bold()),
+        ];
+        let graph = common::Graph {
+            title: "Capacity vs Time".to_string(),
+            color: Color::Red,
+            samples: self.state.samples.get(),
+            x_axis: "Time (m)".to_string(),
+            x_bounds: [0.0, 60.0],
+            x_labels: common::time_labels(self.t_min, MAX_SAMPLES),
+            y_axis: format!("Capacity ({})", self.bix_data.power_unit.as_capacity_str()),
+            y_bounds: [0.0, self.bix_data.design_capacity as f64],
+            y_labels,
+        };
+        common::render_chart(area, buf, graph);
     }
 
-    /*
-    fn get_bix() -> BixData {
-        let result = Acpi::evaluate("\\_SB.ECT0.TBIX");
-        match result {
-            Ok(value) => value.into(),
-            Err(e) => panic!("Failed {}",e),
-        }
-    }
-    */
-
-    fn title_block(title: &str) -> Block<'_> {
-        let title = Line::from(title);
-        Block::new()
-            .borders(Borders::NONE)
-            .padding(Padding::vertical(1))
-            .title(title)
-            .fg(LABEL_COLOR)
-    }
-
-    fn create_status(_area: Rect, status: BstData) -> Vec<Line<'static>> {
+    fn create_info(&self) -> Vec<Line<'static>> {
+        let power_unit = self.bix_data.power_unit;
         vec![
-            Line::raw(format!("State:               {:?}", status.state)),
-            Line::raw(format!("Present Rate:        {:?}mWh", status.rate)),
-            Line::raw(format!("Remaining Capacity:  {:?}mWh", status.capacity)),
-            Line::raw(format!("Present Voltage:     {:?}mV", status.voltage)),
+            Line::raw(format!("Revision:               {}", self.bix_data.revision)),
+            Line::raw(format!(
+                "Power Unit:             {}",
+                self.bix_data.power_unit.as_rate_str()
+            )),
+            Line::raw(format!(
+                "Design Capacity:        {} {}",
+                self.bix_data.design_capacity,
+                power_unit.as_capacity_str()
+            )),
+            Line::raw(format!(
+                "Last Full Capacity:     {} {}",
+                self.bix_data.last_full_capacity,
+                power_unit.as_capacity_str()
+            )),
+            Line::raw(format!(
+                "Battery Technology:     {}",
+                self.bix_data.battery_technology.as_str()
+            )),
+            Line::raw(format!("Design Voltage:         {} mV", self.bix_data.design_voltage)),
+            Line::raw(format!(
+                "Warning Capacity:       {} {}",
+                self.bix_data.warning_capacity,
+                power_unit.as_capacity_str()
+            )),
+            Line::raw(format!(
+                "Low Capacity:           {} {}",
+                self.bix_data.low_capacity,
+                power_unit.as_capacity_str()
+            )),
+            Line::raw(format!("Cycle Count:            {}", self.bix_data.cycle_count)),
+            Line::raw(format!(
+                "Accuracy:               {}%",
+                self.bix_data.accuracy as f64 / 1000.0
+            )),
+            Line::raw(format!("Max Sample Time:        {} ms", self.bix_data.max_sample_time)),
+            Line::raw(format!("Min Sample Time:        {} ms", self.bix_data.min_sample_time)),
+            Line::raw(format!(
+                "Max Average Interval:   {} ms",
+                self.bix_data.max_average_interval
+            )),
+            Line::raw(format!(
+                "Min Average Interval:   {} ms",
+                self.bix_data.min_average_interval
+            )),
+            Line::raw(format!(
+                "Capacity Granularity 1: {} {}",
+                self.bix_data.capacity_gran1,
+                power_unit.as_capacity_str()
+            )),
+            Line::raw(format!(
+                "Capacity Granularity 2: {} {}",
+                self.bix_data.capacity_gran2,
+                power_unit.as_capacity_str()
+            )),
+            Line::raw(format!(
+                "Model Number:           {}",
+                String::from_utf8_lossy(&self.bix_data.model_number)
+            )),
+            Line::raw(format!(
+                "Serial Number:          {}",
+                String::from_utf8_lossy(&self.bix_data.serial_number)
+            )),
+            Line::raw(format!(
+                "Battery Type:           {}",
+                String::from_utf8_lossy(&self.bix_data.battery_type)
+            )),
+            Line::raw(format!(
+                "OEM Info:               {}",
+                String::from_utf8_lossy(&self.bix_data.oem_info)
+            )),
+            Line::raw(format!("Swapping Capability:    {}", self.bix_data.swap_cap.as_str())),
         ]
     }
 
-    /*
-    fn create_info(_area: Rect, info: BixData) -> Vec<Line<'static>> {
-        vec![
-                Line::raw(format!("Design Capacity:     {:?}", info.design_capacity) ),
-                Line::raw(format!("Cycle Count:         {:?}", info.cycle_count)),
-                Line::raw(format!("Model Number:        {:?}", info.model_number)),
-                Line::raw(format!("Serial Number:       {:?}", info.serial_number)),
-            ]
+    fn render_bix(&self, area: Rect, buf: &mut Buffer) {
+        let title = common::title_str_with_status("Battery Info", self.state.bix_success);
+        let title = common::title_block(&title, 1, LABEL_COLOR);
+        Paragraph::new(self.create_info()).block(title).render(area, buf);
     }
-    */
+
+    fn create_status(&self) -> Vec<Line<'static>> {
+        let power_unit = self.bix_data.power_unit;
+        vec![
+            Line::raw(format!("State:               {}", self.bst_data.state.as_str())),
+            Line::raw(format!(
+                "Present Rate:        {} {}",
+                self.bst_data.rate,
+                power_unit.as_rate_str()
+            )),
+            Line::raw(format!(
+                "Remaining Capacity:  {} {}",
+                self.bst_data.capacity,
+                power_unit.as_capacity_str()
+            )),
+            Line::raw(format!("Present Voltage:     {} mV", self.bst_data.voltage)),
+        ]
+    }
+
+    fn render_bst(&self, area: Rect, buf: &mut Buffer) {
+        let title = common::title_str_with_status("Battery Status", self.state.bst_success);
+        let title = common::title_block(&title, 0, LABEL_COLOR);
+        Paragraph::new(self.create_status()).block(title).render(area, buf);
+    }
+
+    fn create_trippoint(&self) -> Vec<Line<'static>> {
+        vec![Line::raw(format!(
+            "Current: {} {}",
+            self.state.btp,
+            self.bix_data.power_unit.as_capacity_str()
+        ))]
+    }
+
+    fn render_btp(&self, area: Rect, buf: &mut Buffer) {
+        let title_str = common::title_str_with_status("Trippoint", self.state.btp_success);
+        let title = common::title_block(&title_str, 0, LABEL_COLOR);
+        let inner = title.inner(area);
+        title.render(area, buf);
+
+        let [current_area, input_area] = common::area_split(inner, Direction::Vertical, 30, 70);
+
+        Paragraph::new(self.create_trippoint()).render(current_area, buf);
+        self.render_btp_input(input_area, buf);
+    }
+
+    fn render_btp_input(&self, area: Rect, buf: &mut Buffer) {
+        let width = area.width.max(3) - 3;
+        let scroll = self.state.btp_input.visual_scroll(width as usize);
+
+        let input = Paragraph::new(self.state.btp_input.value())
+            .style(Style::default())
+            .scroll((0, scroll as u16))
+            .block(Block::bordered().title("Set Trippoint <ENTER>"));
+        input.render(area, buf);
+    }
+
+    fn render_battery(&self, area: Rect, buf: &mut Buffer) {
+        let bat_percent = ((self.bst_data.capacity * 100) / self.bix_data.design_capacity).clamp(0, 100);
+
+        let [tip_area, battery_area] = common::area_split(area, Direction::Vertical, 10, 90);
+        let bar = Bar::default()
+            .value(bat_percent as u64)
+            .text_value(format!("{bat_percent}%"));
+        let color = if self.bst_data.capacity < self.bix_data.low_capacity {
+            BATGAUGE_COLOR_LOW
+        } else if self.bst_data.capacity < self.bix_data.warning_capacity {
+            BATGAUGE_COLOR_MEDIUM
+        } else {
+            BATGAUGE_COLOR_HIGH
+        };
+
+        BarChart::default()
+            .data(BarGroup::default().bars(&[bar]))
+            .max(100)
+            .bar_gap(0)
+            .bar_style(Style::default().fg(color))
+            .block(Block::default().borders(Borders::ALL).border_type(BorderType::Double))
+            .bar_width(battery_area.width - 2)
+            .render(battery_area, buf);
+
+        let width = tip_area.width / 3;
+        let x = tip_area.x + (tip_area.width - width) / 2;
+        let tip_area = Rect {
+            x,
+            y: tip_area.y,
+            width,
+            height: tip_area.height,
+        };
+        Block::default()
+            .borders(Borders::TOP | Borders::LEFT | Borders::RIGHT)
+            .border_type(BorderType::Double)
+            .render(tip_area, buf);
+
+        if self.bst_data.state == ChargeState::Charging {
+            render_bolt(battery_area, buf);
+        }
+    }
+}
+
+fn render_bolt(area: Rect, buf: &mut Buffer) {
+    // Bolt outline
+    const BOLT: [(f64, f64); 7] = [
+        (0.60, 0.05),
+        (0.42, 0.40),
+        (0.64, 0.40),
+        (0.26, 0.95),
+        (0.50, 0.55),
+        (0.32, 0.55),
+        (0.60, 0.05),
+    ];
+    let area = Rect {
+        x: area.x + area.width / 15,
+        y: area.y + area.height / 4,
+        width: area.width,
+        height: area.height / 2,
+    };
+
+    // fill the bolt with dense points using braille marker (2x4 subcells per cell)
+    ratatui::widgets::canvas::Canvas::default()
+        .x_bounds([0.0, 1.0])
+        .y_bounds([0.0, 1.0])
+        .marker(ratatui::symbols::Marker::Braille)
+        .paint(|ctx| {
+            let mut pts: Vec<(f64, f64)> = Vec::new();
+
+            // sampling density (increase if you want smoother)
+            const SX: usize = 160; // sub-samples across X
+            const SY: usize = 320; // sub-samples across Y
+
+            for iy in 0..SY {
+                let y = (iy as f64 + 0.5) / SY as f64;
+                // find polygon-edge intersections with this scanline
+                let mut xs: Vec<f64> = Vec::new();
+                for i in 0..BOLT.len() - 1 {
+                    let (x1, y1) = BOLT[i];
+                    let (x2, y2) = BOLT[i + 1];
+                    if (y1 > y) != (y2 > y) && (y2 - y1).abs() > f64::EPSILON {
+                        let t = (y - y1) / (y2 - y1);
+                        xs.push(x1 + t * (x2 - x1));
+                    }
+                }
+                xs.sort_by(|a, b| a.partial_cmp(b).unwrap());
+
+                // fill between pairs of intersections with sub-sampled points
+                for pair in xs.chunks(2) {
+                    if pair.len() < 2 {
+                        continue;
+                    }
+                    let (x0, x1) = (pair[0], pair[1]);
+                    let steps = ((x1 - x0) * SX as f64).max(1.0).ceil() as usize;
+                    for s in 0..steps {
+                        let x = x0 + (s as f64 + 0.5) / SX as f64;
+                        pts.push((x, y));
+                    }
+                }
+            }
+
+            ctx.draw(&ratatui::widgets::canvas::Points {
+                coords: pts.as_slice(),
+                color: Color::Yellow,
+            });
+        })
+        .render(area, buf);
 }

--- a/rust/src/common.rs
+++ b/rust/src/common.rs
@@ -1,0 +1,124 @@
+use ratatui::{
+    buffer::Buffer,
+    layout::{Constraint, Direction, Layout, Rect},
+    style::{Color, Style, Stylize},
+    symbols,
+    text::{Line, Span},
+    widgets::{Axis, Block, Borders, Chart, Dataset, GraphType, Padding, Widget},
+};
+use std::collections::VecDeque;
+
+#[derive(Default)]
+pub struct SampleBuf<T, const N: usize> {
+    samples: VecDeque<T>,
+}
+
+impl<T: Into<f64> + Copy, const N: usize> SampleBuf<T, N> {
+    // Insert a sample into the buffer and evict the oldest if full
+    pub fn insert(&mut self, sample: T) {
+        self.samples.push_back(sample);
+        if self.samples.len() > N {
+            self.samples.pop_front();
+        }
+    }
+
+    // Converts the buffer into a format that ratatui can use
+    // Probably more efficent way than copying but buffer is small and only called once a second
+    pub fn get(&self) -> Vec<(f64, f64)> {
+        self.samples
+            .iter()
+            .enumerate()
+            .map(|(i, &val)| (i as f64, val.into()))
+            .collect()
+    }
+}
+
+// Properties for rendering a graph
+pub struct Graph {
+    pub title: String,
+    pub color: Color,
+    pub samples: Vec<(f64, f64)>,
+
+    pub x_axis: String,
+    pub x_bounds: [f64; 2],
+    pub x_labels: [Span<'static>; 3],
+
+    pub y_axis: String,
+    pub y_bounds: [f64; 2],
+    pub y_labels: [Span<'static>; 3],
+}
+
+// Convert deciKelvin to degrees Celsius
+pub const fn dk_to_c(dk: u32) -> f64 {
+    (dk as f64 / 10.0) - 273.15
+}
+
+// Split an area in a direction with given percentages
+pub fn area_split(area: Rect, direction: Direction, first: u16, second: u16) -> [Rect; 2] {
+    Layout::default()
+        .direction(direction)
+        .constraints([Constraint::Percentage(first), Constraint::Percentage(second)])
+        .split(area)
+        .as_ref()
+        .try_into()
+        .unwrap()
+}
+
+// Create a wrapping title block
+pub fn title_block(title: &str, padding: u16, label_color: Color) -> Block<'_> {
+    let title = Line::from(title);
+    Block::new()
+        .borders(Borders::ALL)
+        .padding(Padding::vertical(padding))
+        .title(title)
+        .fg(label_color)
+}
+
+// Combines a title string with a visual status indicator character
+pub fn title_str_with_status(title: &str, success: bool) -> String {
+    let status = if success { "✅" } else { "❌" };
+    format!("{title} {status}")
+}
+
+pub fn render_chart(area: Rect, buf: &mut Buffer, graph: Graph) {
+    let samples = &graph.samples[..];
+    let datasets = vec![
+        Dataset::default()
+            .marker(symbols::Marker::Braille)
+            .style(Style::default().fg(graph.color))
+            .graph_type(GraphType::Line)
+            .data(samples),
+    ];
+
+    let chart = Chart::new(datasets)
+        .block(Block::bordered().title(Line::from(graph.title).cyan().bold().centered()))
+        .x_axis(
+            Axis::default()
+                .title(graph.x_axis)
+                .style(Style::default().gray())
+                .bounds(graph.x_bounds)
+                .labels(graph.x_labels),
+        )
+        .y_axis(
+            Axis::default()
+                .title(graph.y_axis)
+                .style(Style::default().gray())
+                .bounds(graph.y_bounds)
+                .labels(graph.y_labels),
+        );
+
+    chart.render(area, buf);
+}
+
+pub fn time_labels(t: usize, max_samples: usize) -> [Span<'static>; 3] {
+    let (start, mid, end) = if t <= max_samples {
+        (0, max_samples / 2, max_samples)
+    } else {
+        (t - max_samples, t - max_samples / 2, t)
+    };
+    [
+        Span::styled(start.to_string(), Style::default().bold()),
+        Span::styled(mid.to_string(), Style::default().bold()),
+        Span::styled(end.to_string(), Style::default().bold()),
+    ]
+}

--- a/rust/src/lib.rs
+++ b/rust/src/lib.rs
@@ -8,6 +8,7 @@ pub mod mock;
 
 pub mod app;
 pub mod battery;
+pub mod common;
 pub mod rtc;
 pub mod thermal;
 pub mod ucsi;
@@ -31,6 +32,15 @@ pub trait Source: Clone {
 
     /// Set fan RPM limit
     fn set_rpm(&self, rpm: f64) -> Result<()>;
+
+    /// Get battery BST data
+    fn get_bst(&self) -> Result<battery::BstData>;
+
+    /// Get battery BIX data
+    fn get_bix(&self) -> Result<battery::BixData>;
+
+    /// Set battery trippoint
+    fn set_btp(&self, trippoint: u32) -> Result<()>;
 }
 
 pub enum Threshold {

--- a/rust/src/thermal.rs
+++ b/rust/src/thermal.rs
@@ -1,48 +1,19 @@
 use crate::app::Module;
+use crate::common;
 use crate::{Source, Threshold};
 use color_eyre::Result;
-
 use ratatui::{
     buffer::Buffer,
     crossterm::event::{Event, KeyCode, KeyEventKind},
-    layout::{Constraint, Direction, Layout, Rect},
+    layout::{Direction, Rect},
     style::{Color, Style, Stylize, palette::tailwind},
-    symbols,
     text::{Line, Span},
-    widgets::{Axis, Block, Borders, Chart, Dataset, Gauge, GraphType, Padding, Paragraph, Widget},
+    widgets::{Block, Gauge, Paragraph, Widget},
 };
-use std::collections::VecDeque;
 use tui_input::{Input, backend::crossterm::EventHandler};
 
 const LABEL_COLOR: Color = tailwind::SLATE.c200;
 const MAX_SAMPLES: usize = 60;
-
-// Split an area in a direction with given percentages
-fn area_split(area: Rect, direction: Direction, first: u16, second: u16) -> [Rect; 2] {
-    Layout::default()
-        .direction(direction)
-        .constraints([Constraint::Percentage(first), Constraint::Percentage(second)])
-        .split(area)
-        .as_ref()
-        .try_into()
-        .unwrap()
-}
-
-// Create a wrapping title block
-fn title_block(title: &str, padding: u16) -> Block<'_> {
-    let title = Line::from(title);
-    Block::new()
-        .borders(Borders::ALL)
-        .padding(Padding::vertical(padding))
-        .title(title)
-        .fg(LABEL_COLOR)
-}
-
-// Combines a title string with a visual status indicator character
-fn title_str_with_status(title: &str, success: bool) -> String {
-    let status = if success { "✅" } else { "❌" };
-    format!("{title} {status}")
-}
 
 fn get_sensor_tmp<S: Source>(source: &S) -> Result<f64> {
     source.get_temperature()
@@ -81,46 +52,6 @@ fn get_fan_levels<S: Source>(source: &S) -> Result<FanStateLevels> {
     Ok(FanStateLevels { on, ramping, max })
 }
 
-// Properties for rendering a graph
-struct Graph {
-    title: &'static str,
-    color: Color,
-    samples: Vec<(f64, f64)>,
-
-    x_axis: &'static str,
-    x_bounds: [f64; 2],
-    x_labels: [Span<'static>; 3],
-
-    y_axis: &'static str,
-    y_bounds: [f64; 2],
-    y_labels: [Span<'static>; 3],
-}
-
-#[derive(Default)]
-struct SampleBuf<T, const N: usize> {
-    samples: VecDeque<T>,
-}
-
-impl<T: Into<f64> + Copy, const N: usize> SampleBuf<T, N> {
-    // Insert a sample into the buffer and evict the oldest if full
-    fn insert(&mut self, sample: T) {
-        self.samples.push_back(sample);
-        if self.samples.len() > N {
-            self.samples.pop_front();
-        }
-    }
-
-    // Converts the buffer into a format that ratatui can use
-    // Probably more efficent way than copying but buffer is small and only called once a second
-    fn get(&self) -> Vec<(f64, f64)> {
-        self.samples
-            .iter()
-            .enumerate()
-            .map(|(i, &val)| (i as f64, val.into()))
-            .collect()
-    }
-}
-
 #[derive(Default)]
 struct SensorThresholds {
     _warn_low: f64,
@@ -135,7 +66,7 @@ struct SensorState {
     temp_success: bool,
     thresholds: SensorThresholds,
     thresholds_success: bool,
-    samples: SampleBuf<f64, MAX_SAMPLES>,
+    samples: common::SampleBuf<f64, MAX_SAMPLES>,
 }
 
 impl SensorState {
@@ -178,7 +109,7 @@ struct FanState {
     bounds_success: bool,
     state_levels: FanStateLevels,
     levels_success: bool,
-    samples: SampleBuf<u32, MAX_SAMPLES>,
+    samples: common::SampleBuf<u32, MAX_SAMPLES>,
 }
 
 impl FanState {
@@ -227,7 +158,7 @@ impl<S: Source> Module for Thermal<S> {
     }
 
     fn render(&self, area: Rect, buf: &mut Buffer) {
-        let [sensor_area, fan_area] = area_split(area, Direction::Horizontal, 50, 50);
+        let [sensor_area, fan_area] = common::area_split(area, Direction::Horizontal, 50, 50);
         self.render_sensor(sensor_area, buf);
         self.render_fan(fan_area, buf);
     }
@@ -261,8 +192,8 @@ impl<S: Source> Thermal<S> {
     }
 
     fn render_sensor(&self, area: Rect, buf: &mut Buffer) {
-        let [chart_area, widget_area] = area_split(area, Direction::Vertical, 70, 30);
-        let [stats_area, thresholds_area] = area_split(widget_area, Direction::Horizontal, 50, 50);
+        let [chart_area, widget_area] = common::area_split(area, Direction::Vertical, 70, 30);
+        let [stats_area, thresholds_area] = common::area_split(widget_area, Direction::Horizontal, 50, 50);
         self.render_sensor_chart(chart_area, buf);
         self.render_sensor_stats(stats_area, buf);
         self.render_sensor_thresholds(thresholds_area, buf);
@@ -280,18 +211,18 @@ impl<S: Source> Thermal<S> {
                 Style::default().bold(),
             ),
         ];
-        let graph = Graph {
-            title: "Temperature vs Time",
+        let graph = common::Graph {
+            title: "Temperature vs Time".to_string(),
             color: Color::Red,
             samples: self.sensor.samples.get(),
-            x_axis: "Time (s)",
+            x_axis: "Time (s)".to_string(),
             x_bounds: [0.0, 60.0],
-            x_labels: self.time_labels(),
-            y_axis: "Temperature (°C)",
+            x_labels: common::time_labels(self.t, MAX_SAMPLES),
+            y_axis: "Temperature (°C)".to_string(),
             y_bounds: [0.0, self.sensor.thresholds.critical + 5.0],
             y_labels,
         };
-        self.render_chart(area, buf, graph);
+        common::render_chart(area, buf, graph);
     }
 
     fn create_sensor_stats(&self) -> Vec<Line<'static>> {
@@ -299,11 +230,11 @@ impl<S: Source> Thermal<S> {
     }
 
     fn render_sensor_stats(&self, area: Rect, buf: &mut Buffer) {
-        let title_str = title_str_with_status("Live Temperature", self.sensor.temp_success);
-        let stats_title = title_block(&title_str, 1);
+        let title_str = common::title_str_with_status("Live Temperature", self.sensor.temp_success);
+        let stats_title = common::title_block(&title_str, 1, LABEL_COLOR);
         let inner = stats_title.inner(area);
         stats_title.render(area, buf);
-        let [temp_area, gauge_area] = area_split(inner, Direction::Vertical, 50, 50);
+        let [temp_area, gauge_area] = common::area_split(inner, Direction::Vertical, 50, 50);
 
         let gauge_color = if self.sensor.skin_temp < self.sensor.thresholds.warn_high {
             tailwind::GREEN.c700
@@ -331,16 +262,16 @@ impl<S: Source> Thermal<S> {
     }
 
     fn render_sensor_thresholds(&self, area: Rect, buf: &mut Buffer) {
-        let title_str = title_str_with_status("Thresholds", self.sensor.thresholds_success);
-        let title = title_block(&title_str, 1);
+        let title_str = common::title_str_with_status("Thresholds", self.sensor.thresholds_success);
+        let title = common::title_block(&title_str, 1, LABEL_COLOR);
         Paragraph::new(self.create_sensor_thresholds())
             .block(title)
             .render(area, buf);
     }
 
     fn render_fan(&self, area: Rect, buf: &mut Buffer) {
-        let [chart_area, widget_area] = area_split(area, Direction::Vertical, 70, 30);
-        let [stats_area, levels_area] = area_split(widget_area, Direction::Horizontal, 50, 50);
+        let [chart_area, widget_area] = common::area_split(area, Direction::Vertical, 70, 30);
+        let [stats_area, levels_area] = common::area_split(widget_area, Direction::Horizontal, 50, 50);
         self.render_fan_chart(chart_area, buf);
         self.render_fan_stats(stats_area, buf);
         self.render_fan_levels(levels_area, buf);
@@ -352,18 +283,18 @@ impl<S: Source> Thermal<S> {
             Span::styled((self.fan.rpm_bounds.max / 2.0).to_string(), Style::default().bold()),
             Span::styled(self.fan.rpm_bounds.max.to_string(), Style::default().bold()),
         ];
-        let graph = Graph {
-            title: "Fan RPM vs Time",
+        let graph = common::Graph {
+            title: "Fan RPM vs Time".to_string(),
             color: Color::Blue,
             samples: self.fan.samples.get(),
-            x_axis: "Time (s)",
+            x_axis: "Time (s)".to_string(),
             x_bounds: [0.0, 60.0],
-            x_labels: self.time_labels(),
-            y_axis: "RPM",
+            x_labels: common::time_labels(self.t, MAX_SAMPLES),
+            y_axis: "RPM".to_string(),
             y_bounds: [0.0, self.fan.rpm_bounds.max],
             y_labels,
         };
-        self.render_chart(area, buf, graph);
+        common::render_chart(area, buf, graph);
     }
 
     fn create_fan_stats(&self) -> Vec<Line<'static>> {
@@ -376,12 +307,12 @@ impl<S: Source> Thermal<S> {
     }
 
     fn render_fan_stats(&self, area: Rect, buf: &mut Buffer) {
-        let title_str = title_str_with_status("Live Fan RPM", self.fan.rpm_success && self.fan.bounds_success);
-        let title = title_block(&title_str, 0);
+        let title_str = common::title_str_with_status("Live Fan RPM", self.fan.rpm_success && self.fan.bounds_success);
+        let title = common::title_block(&title_str, 0, LABEL_COLOR);
         let inner = title.inner(area);
         title.render(area, buf);
 
-        let [rpm_area, input_area] = area_split(inner, Direction::Vertical, 30, 70);
+        let [rpm_area, input_area] = common::area_split(inner, Direction::Vertical, 30, 70);
 
         Paragraph::new(self.create_fan_stats()).render(rpm_area, buf);
         self.render_fan_rpm_input(input_area, buf);
@@ -396,8 +327,8 @@ impl<S: Source> Thermal<S> {
     }
 
     fn render_fan_levels(&self, area: Rect, buf: &mut Buffer) {
-        let title_str = title_str_with_status("Fan State Levels", self.fan.levels_success);
-        let title = title_block(&title_str, 1);
+        let title_str = common::title_str_with_status("Fan State Levels", self.fan.levels_success);
+        let title = common::title_block(&title_str, 1, LABEL_COLOR);
         Paragraph::new(self.create_fan_levels()).block(title).render(area, buf);
     }
 
@@ -410,50 +341,5 @@ impl<S: Source> Thermal<S> {
             .scroll((0, scroll as u16))
             .block(Block::bordered().title("Set Fan RPM <ENTER>"));
         input.render(area, buf);
-    }
-
-    fn time_labels(&self) -> [Span<'static>; 3] {
-        if self.t <= MAX_SAMPLES {
-            ["0".bold(), "30".bold(), "60".bold()]
-        } else {
-            let a = (self.t - 60).to_string();
-            let b = (self.t - 30).to_string();
-            let c = self.t.to_string();
-            [
-                Span::styled(a, Style::default().bold()),
-                Span::styled(b, Style::default().bold()),
-                Span::styled(c, Style::default().bold()),
-            ]
-        }
-    }
-
-    fn render_chart(&self, area: Rect, buf: &mut Buffer, graph: Graph) {
-        let samples = &graph.samples[..];
-        let datasets = vec![
-            Dataset::default()
-                .marker(symbols::Marker::Braille)
-                .style(Style::default().fg(graph.color))
-                .graph_type(GraphType::Line)
-                .data(samples),
-        ];
-
-        let chart = Chart::new(datasets)
-            .block(Block::bordered().title(Line::from(graph.title).cyan().bold().centered()))
-            .x_axis(
-                Axis::default()
-                    .title(graph.x_axis)
-                    .style(Style::default().gray())
-                    .bounds(graph.x_bounds)
-                    .labels(graph.x_labels),
-            )
-            .y_axis(
-                Axis::default()
-                    .title(graph.y_axis)
-                    .style(Style::default().gray())
-                    .bounds(graph.y_bounds)
-                    .labels(graph.y_labels),
-            );
-
-        chart.render(area, buf);
     }
 }


### PR DESCRIPTION
This PR fleshes out the battery tab. Some minor refactoring was done to pull shared code into a `common` module.

Full-disclosure: The `render_bolt()` function is AI-generated as creating arbitrary filled shapes in ratatui is not so easy.

Resolves #24 

<img width="1115" height="628" alt="image" src="https://github.com/user-attachments/assets/dfcd2e5b-5ae7-4eb7-8b07-e80eaf25ea1f" />
