### PR TITLE
ec-test-app: Add serial source

### DIFF
--- a/rust/Cargo.lock
+++ b/rust/Cargo.lock
@@ -43,7 +43,7 @@ dependencies = [
  "proc-macro-error2",
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.114",
 ]
 
 [[package]]
@@ -74,6 +74,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5deb64efa5bd81e31fcd1938615a6d98c82eafcbcd787162b6f63b91d6bac5b3"
 dependencies = [
  "rustc_version",
+]
+
+[[package]]
+name = "battery-service-messages"
+version = "0.1.0"
+source = "git+https://github.com/OpenDevicePartnership/embedded-services?branch=v0.2.0#16c4364c8c8c6b61c9c01661c8d1488cb55fd6aa"
+dependencies = [
+ "embedded-batteries-async",
+ "embedded-services",
+ "num_enum",
 ]
 
 [[package]]
@@ -122,19 +132,25 @@ checksum = "f48d6ace212fdf1b45fd6b566bb40808415344642b76c3224c07c8df9da81e97"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.114",
 ]
 
 [[package]]
 name = "bitfield-struct"
-version = "0.10.1"
+version = "0.12.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2be5a46ba01b60005ae2c51a36a29cfe134bcacae2dd5cedcd4615fbaad1494b"
+checksum = "8769c4854c5ada2852ddf6fd09d15cf43d4c2aaeccb4de6432f5402f08a6003b"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.114",
 ]
+
+[[package]]
+name = "bitflags"
+version = "1.3.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bef38d45163c2f1dde094a7dfd33ccf595c92905c8f8f4fdc18d06fb1037718a"
 
 [[package]]
 name = "bitflags"
@@ -223,6 +239,22 @@ dependencies = [
 ]
 
 [[package]]
+name = "core-foundation"
+version = "0.10.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b55271e5c8c478ad3f38ad24ef34923091e0548492a266d19b3c0b4d82574c63"
+dependencies = [
+ "core-foundation-sys",
+ "libc",
+]
+
+[[package]]
+name = "core-foundation-sys"
+version = "0.8.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "773648b94d0e5d620f64f280777445740e61fe701025087ec8b57f45c791888b"
+
+[[package]]
 name = "cortex-m"
 version = "0.7.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -251,7 +283,7 @@ checksum = "e37549a379a9e0e6e576fd208ee60394ccb8be963889eebba3ffe0980364f472"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.114",
 ]
 
 [[package]]
@@ -266,7 +298,7 @@ version = "0.28.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "829d955a0bb380ef178a640b91779e3987da38c9aea133b20614cfed8cdea9c6"
 dependencies = [
- "bitflags",
+ "bitflags 2.9.1",
  "crossterm_winapi",
  "mio",
  "parking_lot",
@@ -306,7 +338,7 @@ dependencies = [
  "proc-macro2",
  "quote",
  "strsim",
- "syn",
+ "syn 2.0.114",
 ]
 
 [[package]]
@@ -317,7 +349,7 @@ checksum = "fc34b93ccb385b40dc71c6fceac4b2ad23662c7eeb248cf10d529b7e055b6ead"
 dependencies = [
  "darling_core",
  "quote",
- "syn",
+ "syn 2.0.114",
 ]
 
 [[package]]
@@ -333,14 +365,18 @@ dependencies = [
 name = "ec_demo"
 version = "0.1.0"
 dependencies = [
+ "battery-service-messages",
  "color-eyre",
  "crossterm",
  "embedded-mcu-hal",
+ "embedded-services",
  "env_logger",
  "log",
  "num_enum",
  "ratatui",
+ "serialport",
  "strum 0.27.2",
+ "thermal-service-messages",
  "time-alarm-service-messages",
  "tui-input",
  "uuid",
@@ -393,21 +429,21 @@ dependencies = [
 
 [[package]]
 name = "embedded-batteries"
-version = "0.2.1"
+version = "0.3.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "31e14d288a59ef41f4e05468eae9b1c9fef6866977cea86d3f1a1ced295b6cab"
+checksum = "40f975432b4e146342a1589c563cffab6b7a692024cb511bf87b6bfe78c84125"
 dependencies = [
  "bitfield-struct",
- "bitflags",
+ "bitflags 2.9.1",
  "embedded-hal 1.0.0",
  "zerocopy",
 ]
 
 [[package]]
 name = "embedded-batteries-async"
-version = "0.2.1"
+version = "0.3.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "98cb543f4eea7e2c57544f345a5cf40fd90e9d3593b96cb7515f6c1d62c7fc68"
+checksum = "a3bf0e4be67770cfc31f1cea8b73baf98c0baf2c57d6bd8c3a4c315acb1d8bd4"
 dependencies = [
  "bitfield-struct",
  "embedded-batteries",
@@ -479,10 +515,10 @@ dependencies = [
 [[package]]
 name = "embedded-services"
 version = "0.1.0"
-source = "git+https://github.com/OpenDevicePartnership/embedded-services?branch=v0.2.0#f4f36486e4b4f0e9a242c1c50a806b6c57b5b87d"
+source = "git+https://github.com/OpenDevicePartnership/embedded-services?branch=v0.2.0#16c4364c8c8c6b61c9c01661c8d1488cb55fd6aa"
 dependencies = [
  "bitfield 0.17.0",
- "bitflags",
+ "bitflags 2.9.1",
  "bitvec",
  "cfg-if",
  "cortex-m",
@@ -551,7 +587,7 @@ version = "0.1.0"
 source = "git+https://github.com/OpenDevicePartnership/haf-ec-service#9805f13c044b0e314d415410c57a8a59a40eabeb"
 dependencies = [
  "bit-register",
- "bitflags",
+ "bitflags 2.9.1",
  "num-traits",
  "num_enum",
  "static_assertions",
@@ -636,6 +672,12 @@ dependencies = [
 
 [[package]]
 name = "heck"
+version = "0.4.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "95505c38b4572b2d910cecb0281560f54b440a19336cbbcb27bf6ce6adc6f5a8"
+
+[[package]]
+name = "heck"
 version = "0.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2304e00983f87ffb38b55b444b5e3b60a884b5d30c0fca7d82fe33449bbe55ea"
@@ -699,7 +741,17 @@ dependencies = [
  "indoc",
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.114",
+]
+
+[[package]]
+name = "io-kit-sys"
+version = "0.4.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "617ee6cf8e3f66f3b4ea67a4058564628cde41901316e19f559e14c7c72c5e7b"
+dependencies = [
+ "core-foundation-sys",
+ "mach2",
 ]
 
 [[package]]
@@ -750,6 +802,26 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1171693293099992e19cddea4e8b849964e9846f4acee11b3948bcc337be8776"
 
 [[package]]
+name = "libudev"
+version = "0.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "78b324152da65df7bb95acfcaab55e3097ceaab02fb19b228a9eb74d55f135e0"
+dependencies = [
+ "libc",
+ "libudev-sys",
+]
+
+[[package]]
+name = "libudev-sys"
+version = "0.1.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3c8469b4a23b962c1396b9b451dda50ef5b283e8dd309d69033475fa9b334324"
+dependencies = [
+ "libc",
+ "pkg-config",
+]
+
+[[package]]
 name = "linux-raw-sys"
 version = "0.4.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -784,6 +856,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "234cf4f4a04dc1f57e24b96cc0cd600cf2af460d4161ac5ecdd0af8e1f3b2a38"
 dependencies = [
  "hashbrown",
+]
+
+[[package]]
+name = "mach2"
+version = "0.4.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d640282b302c0bb0a2a8e0233ead9035e3bed871f0b7e81fe4a1ec829765db44"
+dependencies = [
+ "libc",
 ]
 
 [[package]]
@@ -841,6 +922,17 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8d5439c4ad607c3c23abf66de8c8bf57ba8adcd1f129e699851a6e43935d339d"
 
 [[package]]
+name = "nix"
+version = "0.26.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "598beaf3cc6fdd9a5dfb1630c2800c7acd31df7aaf0f565796fba2b53ca1af1b"
+dependencies = [
+ "bitflags 1.3.2",
+ "cfg-if",
+ "libc",
+]
+
+[[package]]
 name = "num-traits"
 version = "0.2.19"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -867,7 +959,7 @@ checksum = "ff32365de1b6743cb203b710788263c44a03de03802daf96092f2da4fe6ba4d7"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.114",
 ]
 
 [[package]]
@@ -927,6 +1019,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3b3cff922bd51709b605d9ead9aa71031d81447142d828eb4a6eba76fe619f9b"
 
 [[package]]
+name = "pkg-config"
+version = "0.3.32"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7edddbd0b52d732b21ad9a5fab5c704c14cd949e5e9a1ec5929a24fded1b904c"
+
+[[package]]
 name = "portable-atomic"
 version = "1.13.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -964,9 +1062,9 @@ dependencies = [
 
 [[package]]
 name = "quote"
-version = "1.0.44"
+version = "1.0.40"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "21b2ebcf727b7760c461f091f9f0f539b77b8e87f2fd88131e7f1b433b3cece4"
+checksum = "1885c039570dc00dcb4ff087a89e185fd56bae234ddc7f056a945bf36467248d"
 dependencies = [
  "proc-macro2",
 ]
@@ -983,7 +1081,7 @@ version = "0.29.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "eabd94c2f37801c20583fc49dd5cd6b0ba68c716787c2dd6ed18571e1e63117b"
 dependencies = [
- "bitflags",
+ "bitflags 2.9.1",
  "cassowary",
  "compact_str",
  "crossterm",
@@ -1004,7 +1102,7 @@ version = "0.5.17"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5407465600fb0548f1442edf71dd20683c6ed326200ace4b1ef0763521bb3b77"
 dependencies = [
- "bitflags",
+ "bitflags 2.9.1",
 ]
 
 [[package]]
@@ -1057,7 +1155,7 @@ version = "0.38.44"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "fdb5bc1ae2baa591800df16c9ca78619bf65c0488b41b96ccec5d11220d8c154"
 dependencies = [
- "bitflags",
+ "bitflags 2.9.1",
  "errno",
  "libc",
  "linux-raw-sys",
@@ -1124,7 +1222,27 @@ checksum = "d540f220d3187173da220f885ab66608367b6574e925011a9353e4badda91d79"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.114",
+]
+
+[[package]]
+name = "serialport"
+version = "4.8.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "21f60a586160667241d7702c420fc223939fb3c0bb8d3fac84f78768e8970dee"
+dependencies = [
+ "bitflags 2.9.1",
+ "cfg-if",
+ "core-foundation",
+ "core-foundation-sys",
+ "io-kit-sys",
+ "libudev",
+ "mach2",
+ "nix",
+ "quote",
+ "scopeguard",
+ "unescaper",
+ "windows-sys 0.52.0",
 ]
 
 [[package]]
@@ -1223,11 +1341,11 @@ version = "0.26.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4c6bee85a5a24955dc440386795aa378cd9cf82acd5f764469152d2270e581be"
 dependencies = [
- "heck",
+ "heck 0.5.0",
  "proc-macro2",
  "quote",
  "rustversion",
- "syn",
+ "syn 2.0.114",
 ]
 
 [[package]]
@@ -1236,22 +1354,33 @@ version = "0.27.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7695ce3845ea4b33927c055a39dc438a45b059f7c1b3d91d38d10355fb8cbca7"
 dependencies = [
- "heck",
+ "heck 0.5.0",
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.114",
 ]
 
 [[package]]
 name = "subenum"
-version = "1.1.3"
+version = "1.1.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ec3d08fe7078c57309d5c3d938e50eba95ba1d33b9c3a101a8465fc6861a5416"
+checksum = "4f5d5dfb8556dd04017db5e318bbeac8ab2b0c67b76bf197bfb79e9b29f18ecf"
 dependencies = [
- "heck",
+ "heck 0.4.1",
  "proc-macro2",
  "quote",
- "syn",
+ "syn 1.0.109",
+]
+
+[[package]]
+name = "syn"
+version = "1.0.109"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "72b64191b275b66ffe2469e8af2c1cfe3bafa67b529ead792a6d0160888b4237"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "unicode-ident",
 ]
 
 [[package]]
@@ -1281,6 +1410,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "thermal-service-messages"
+version = "0.1.0"
+source = "git+https://github.com/OpenDevicePartnership/embedded-services?branch=v0.2.0#16c4364c8c8c6b61c9c01661c8d1488cb55fd6aa"
+dependencies = [
+ "embedded-services",
+ "num_enum",
+ "uuid",
+]
+
+[[package]]
 name = "thiserror"
 version = "2.0.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1297,7 +1436,7 @@ checksum = "ebc4ee7f67670e9b64d05fa4253e753e016c6c95ff35b89b7941d6b856dec1d5"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.114",
 ]
 
 [[package]]
@@ -1312,7 +1451,7 @@ dependencies = [
 [[package]]
 name = "time-alarm-service-messages"
 version = "0.1.0"
-source = "git+https://github.com/OpenDevicePartnership/embedded-services?branch=v0.2.0#f4f36486e4b4f0e9a242c1c50a806b6c57b5b87d"
+source = "git+https://github.com/OpenDevicePartnership/embedded-services?branch=v0.2.0#16c4364c8c8c6b61c9c01661c8d1488cb55fd6aa"
 dependencies = [
  "bitfield 0.17.0",
  "embedded-mcu-hal",
@@ -1370,6 +1509,15 @@ checksum = "911e93158bf80bbc94bad533b2b16e3d711e1132d69a6a6980c3920a63422c19"
 dependencies = [
  "ratatui",
  "unicode-width 0.2.0",
+]
+
+[[package]]
+name = "unescaper"
+version = "0.1.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4064ed685c487dbc25bd3f0e9548f2e34bab9d18cefc700f9ec2dba74ba1138e"
+dependencies = [
+ "thiserror",
 ]
 
 [[package]]
@@ -1488,6 +1636,15 @@ name = "windows-link"
 version = "0.1.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5e6ad25900d524eaabdbbb96d20b4311e1e7ae1699af4fb28c17ae66c80d798a"
+
+[[package]]
+name = "windows-sys"
+version = "0.52.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "282be5f36a8ce781fad8c8ae18fa3f9beff57ec1b52cb3de0789201425d9a33d"
+dependencies = [
+ "windows-targets 0.52.6",
+]
 
 [[package]]
 name = "windows-sys"
@@ -1662,5 +1819,5 @@ checksum = "0c15e1b46eff7c6c91195752e0eeed8ef040e391cdece7c25376957d5f15df22"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.114",
 ]

--- a/rust/Cargo.toml
+++ b/rust/Cargo.toml
@@ -6,7 +6,7 @@ license = "MIT"
 description = "RUST based UI to demo EC features"
 authors = ["Phil Weber <philweber@microsoft.com>"]
 repository = "https://github.com/OpenDevicePartnership/ec_demo"
-rust-version = "1.85"
+rust-version = "1.88"
 
 [dependencies]
 # dependencies for all targets
@@ -21,9 +21,17 @@ tui-input = "0.14.0"
 uuid = { version = "1.17.0", default-features = false }
 time-alarm-service-messages = { git = "https://github.com/OpenDevicePartnership/embedded-services", branch = "v0.2.0" }
 embedded-mcu-hal = { git = "https://github.com/OpenDevicePartnership/embedded-mcu" }
+thermal-service-messages = { git = "https://github.com/OpenDevicePartnership/embedded-services", branch = "v0.2.0" }
+battery-service-messages = { git = "https://github.com/OpenDevicePartnership/embedded-services", branch = "v0.2.0" }
+
+# Serial feature specific
+serialport = { version = "4.8.1", optional = true }
+embedded-services = { git = "https://github.com/OpenDevicePartnership/embedded-services", branch = "v0.2.0", optional = true }
 
 [features]
 mock = []
+acpi = []
+serial = ["dep:serialport", "dep:embedded-services"]
 
 [lints.clippy]
 suspicious = "forbid"

--- a/rust/build.rs
+++ b/rust/build.rs
@@ -4,8 +4,8 @@ use std::fs;
 
 fn main() {
     // Don't do a fancy build if we're just testing our TUI
-    if env::var("CARGO_FEATURE_MOCK").is_ok() {
-        println!("cargo:warning=Skipping build.rs logic because 'mock' feature is enabled.");
+    if env::var("CARGO_FEATURE_ACPI").is_err() {
+        println!("cargo:warning=Skipping build.rs logic because 'acpi' feature is not enabled.");
         return;
     }
 

--- a/rust/src/app.rs
+++ b/rust/src/app.rs
@@ -125,16 +125,16 @@ impl<S: Source + Clone + 'static> App<S> {
 
     fn handle_events(&mut self) -> std::io::Result<()> {
         let evt = event::read()?;
-        if let Event::Key(key) = evt {
-            if key.kind == KeyEventKind::Press {
-                match key.code {
-                    KeyCode::Char('l') | KeyCode::Right => self.next_tab(),
-                    KeyCode::Char('h') | KeyCode::Left => self.previous_tab(),
-                    KeyCode::Char('q') | KeyCode::Esc => self.quit(),
+        if let Event::Key(key) = evt
+            && key.kind == KeyEventKind::Press
+        {
+            match key.code {
+                KeyCode::Char('l') | KeyCode::Right => self.next_tab(),
+                KeyCode::Char('h') | KeyCode::Left => self.previous_tab(),
+                KeyCode::Char('q') | KeyCode::Esc => self.quit(),
 
-                    // Let the current tab handle event in this case
-                    _ => self.handle_tab_event(&evt),
-                }
+                // Let the current tab handle event in this case
+                _ => self.handle_tab_event(&evt),
             }
         }
         Ok(())

--- a/rust/src/common.rs
+++ b/rust/src/common.rs
@@ -8,6 +8,17 @@ use ratatui::{
 };
 use std::collections::VecDeque;
 
+pub mod guid {
+    pub const _SENSOR_CRT_TEMP: uuid::Uuid = uuid::uuid!("218246e7-baf6-45f1-aa13-07e4845256b8");
+    pub const _SENSOR_PROCHOT_TEMP: uuid::Uuid = uuid::uuid!("22dc52d2-fd0b-47ab-95b8-26552f9831a5");
+    pub const FAN_ON_TEMP: uuid::Uuid = uuid::uuid!("ba17b567-c368-48d5-bc6f-a312a41583c1");
+    pub const FAN_RAMP_TEMP: uuid::Uuid = uuid::uuid!("3a62688c-d95b-4d2d-bacc-90d7a5816bcd");
+    pub const FAN_MAX_TEMP: uuid::Uuid = uuid::uuid!("dcb758b1-f0fd-4ec7-b2c0-ef1e2a547b76");
+    pub const FAN_MIN_RPM: uuid::Uuid = uuid::uuid!("db261c77-934b-45e2-9742-256c62badb7a");
+    pub const FAN_MAX_RPM: uuid::Uuid = uuid::uuid!("5cf839df-8be7-42b9-9ac5-3403ca2c8a6a");
+    pub const FAN_CURRENT_RPM: uuid::Uuid = uuid::uuid!("adf95492-0776-4ffc-84f3-b6c8b5269683");
+}
+
 #[derive(Default)]
 pub struct SampleBuf<T, const N: usize> {
     samples: VecDeque<T>,

--- a/rust/src/lib.rs
+++ b/rust/src/lib.rs
@@ -1,14 +1,25 @@
+const _: () = {
+    let count = cfg!(feature = "mock") as u8 + cfg!(feature = "acpi") as u8 + cfg!(feature = "serial") as u8;
+    assert!(
+        count == 1,
+        "Exactly one of the following features must be enabled: `mock`, `acpi`, or `serial`."
+    );
+};
+
 use color_eyre::Result;
 
 use time_alarm_service_messages::{
     AcpiTimerId, AcpiTimestamp, AlarmExpiredWakePolicy, AlarmTimerSeconds, TimeAlarmDeviceCapabilities, TimerStatus,
 };
 
-#[cfg(not(feature = "mock"))]
+#[cfg(feature = "acpi")]
 pub mod acpi;
 
 #[cfg(feature = "mock")]
 pub mod mock;
+
+#[cfg(feature = "serial")]
+pub mod serial;
 
 pub mod app;
 pub mod battery;
@@ -17,6 +28,8 @@ pub mod rtc;
 pub mod thermal;
 pub mod ucsi;
 pub mod widgets;
+
+use battery_service_messages::{BixFixedStrings, BstReturn};
 
 /// Trait implemented by all data sources
 pub trait Source: Clone + RtcSource {
@@ -39,10 +52,10 @@ pub trait Source: Clone + RtcSource {
     fn set_rpm(&self, rpm: f64) -> Result<()>;
 
     /// Get battery BST data
-    fn get_bst(&self) -> Result<battery::BstData>;
+    fn get_bst(&self) -> Result<BstReturn>;
 
     /// Get battery BIX data
-    fn get_bix(&self) -> Result<battery::BixData>;
+    fn get_bix(&self) -> Result<BixFixedStrings>;
 
     /// Set battery trippoint
     fn set_btp(&self, trippoint: u32) -> Result<()>;

--- a/rust/src/main.rs
+++ b/rust/src/main.rs
@@ -3,13 +3,36 @@ use ec_demo::app::App;
 
 fn main() -> Result<()> {
     color_eyre::install()?;
-    let terminal = ratatui::init();
 
-    #[cfg(not(feature = "mock"))]
-    let source = ec_demo::acpi::Acpi::default();
+    let terminal = ratatui::init();
 
     #[cfg(feature = "mock")]
     let source = ec_demo::mock::Mock::default();
+
+    #[cfg(feature = "acpi")]
+    let source = ec_demo::acpi::Acpi::default();
+
+    #[cfg(feature = "serial")]
+    let source = {
+        // Revisit: Quick and easy for grabbing command line args, but when
+        // debug tab PR is merged this can switch to clap for arg parsing
+        let mut args = std::env::args().skip(1);
+        let path = args.next().expect("Serial port path must be provided");
+        let flow_control = args.next().expect("Flow control mode must be provided");
+        let flow_control = match flow_control.as_str() {
+            "hw" => true,
+            "none" => false,
+            _ => panic!("Flow control mode must be either `hw` or `none`"),
+        };
+
+        let baud = args
+            .next()
+            .unwrap_or("115200".to_string())
+            .parse::<u32>()
+            .expect("Serial baud rate must be a u32");
+
+        ec_demo::serial::Serial::new(path.as_str(), baud, flow_control)
+    };
 
     App::new(source).run(terminal)
 }

--- a/rust/src/serial.rs
+++ b/rust/src/serial.rs
@@ -1,0 +1,354 @@
+use crate::{RtcSource, Source, Threshold, common};
+use battery_service_messages::{AcpiBatteryRequest, AcpiBatteryResponse, BixFixedStrings, BstReturn, Btp};
+use color_eyre::{Result, eyre::eyre};
+use embedded_services::relay::{MessageSerializationError, SerializableMessage};
+use serialport::SerialPort;
+use std::{
+    sync::{Arc, Mutex},
+    time::Duration,
+};
+use thermal_service_messages::{ThermalRequest, ThermalResponse};
+use time_alarm_service_messages::{
+    AcpiTimeAlarmRequest, AcpiTimeAlarmResponse, AcpiTimerId, AcpiTimestamp, AlarmExpiredWakePolicy, AlarmTimerSeconds,
+    TimeAlarmDeviceCapabilities, TimerStatus,
+};
+
+// If it took longer than a second to receive a response, something is definitely wrong
+const READ_TIMEOUT: Duration = Duration::from_millis(1000);
+
+const SMBUS_HEADER_SZ: usize = 4;
+const SMBUS_LEN_IDX: usize = 2;
+const MCTP_FLAGS_IDX: usize = 7;
+const MCTP_HEADER_SZ: usize = 5;
+const ODP_HEADER_SZ: usize = 2; // This does not include the 2 byte command code
+const HEADER_SZ: usize = SMBUS_HEADER_SZ + MCTP_HEADER_SZ + ODP_HEADER_SZ;
+const CMD_CODE_SZ: usize = 2;
+const BUFFER_SZ: usize = 256;
+const MCTP_MAX_PACKET_LEN: usize = 69;
+
+const THERMAL_VAR_LEN: u16 = 4;
+const SENSOR_INSTANCE: u8 = 0;
+const BATTERY_INSTANCE: u8 = 0;
+
+#[derive(Clone, Copy, Debug)]
+enum Destination {
+    Battery,
+    Thermal,
+    TimeAlarm,
+}
+
+impl From<Destination> for u8 {
+    fn from(dst: Destination) -> Self {
+        match dst {
+            Destination::Battery => 0x08,
+            Destination::Thermal => 0x09,
+            Destination::TimeAlarm => 0x0B,
+        }
+    }
+}
+
+fn prepend_headers(buffer: &mut [u8], dst: Destination, payload_sz: usize) {
+    // SMBUS
+    buffer[0] = 0x2;
+    buffer[1] = 0xF;
+    buffer[2] = (MCTP_HEADER_SZ + ODP_HEADER_SZ + payload_sz) as u8;
+    buffer[3] = 0x1;
+
+    // MCTP
+    buffer[4] = 0x1;
+    buffer[5] = dst.into();
+    buffer[6] = 0x80;
+    buffer[7] = 0xD3;
+    buffer[8] = 0x7D; // Additional MCTP message type header byte
+
+    // ODP
+    buffer[9] = 1 << 1;
+    buffer[10] = dst.into();
+}
+
+fn append_cmd(
+    to: &mut [u8],
+    from: impl SerializableMessage,
+    cmd_code: u16,
+) -> Result<usize, MessageSerializationError> {
+    to[HEADER_SZ..HEADER_SZ + CMD_CODE_SZ].copy_from_slice(&cmd_code.to_be_bytes());
+    let payload_sz = from.serialize(&mut to[HEADER_SZ + CMD_CODE_SZ..])?;
+    Ok(payload_sz + CMD_CODE_SZ)
+}
+
+#[derive(Clone)]
+pub struct Serial {
+    port: Arc<Mutex<Box<dyn SerialPort>>>,
+}
+
+impl Serial {
+    pub fn new(path: &str, baud_rate: u32, flow_control: bool) -> Self {
+        let flow_control = if flow_control {
+            serialport::FlowControl::Hardware
+        } else {
+            serialport::FlowControl::None
+        };
+
+        let port = serialport::new(path, baud_rate)
+            .flow_control(flow_control)
+            .timeout(READ_TIMEOUT)
+            .open()
+            .expect("Serial port must be available");
+        port.clear(serialport::ClearBuffer::All)
+            .expect("Port must be available");
+
+        Self {
+            port: Arc::new(Mutex::new(port)),
+        }
+    }
+}
+
+impl Serial {
+    fn send<REQ: SerializableMessage + Copy, RESP: SerializableMessage>(
+        &self,
+        dst: Destination,
+        request: REQ,
+    ) -> Result<RESP> {
+        let mut buffer = [0u8; BUFFER_SZ];
+
+        // Serialize command into buffer
+        let request_sz = append_cmd(&mut buffer, request, request.discriminant())
+            .map_err(|e| eyre!("Serialization error: {e:?}"))?;
+
+        // NOTE: The `mctp-rs` crate does not appear to support serializing requests and deserializing
+        // responses (only the opposite), so we have to do manual serialization until that is changed.
+
+        // And now that we know request size, serialize headers into beginning of buffer
+        prepend_headers(&mut buffer, dst, request_sz);
+
+        let mut port = self.port.lock().expect("Mutex must not be poisoned");
+
+        // Write entire request packet
+        // We first clear the input buffer in case there's anything left over if we had to bail out
+        // early on previous call due to error
+        port.clear(serialport::ClearBuffer::Input)
+            .map_err(|e| eyre!("Serial error: {e:?}"))?;
+        port.write_all(&buffer[..HEADER_SZ + request_sz])
+            .map_err(|e| eyre!("Serial error: {e:?}"))?;
+        port.flush().map_err(|e| eyre!("Serial error: {e:?}"))?;
+
+        // Read response packets
+        let mut response_buf = [0u8; BUFFER_SZ];
+        let mut offset = 0;
+        let mut cmd_code = 0;
+        loop {
+            // Wait for SMBUS header from response packet
+            let mut buffer = [0u8; BUFFER_SZ];
+            port.read_exact(&mut buffer[..SMBUS_HEADER_SZ])
+                .map_err(|e| eyre!("Serial error: {e:?}"))?;
+
+            // Get the length of the response and do a sanity check on it
+            let len = buffer[SMBUS_LEN_IDX] as usize;
+            if !(MCTP_HEADER_SZ..=MCTP_MAX_PACKET_LEN).contains(&len) {
+                return Err(eyre!("Serial error: Invalid MCTP packet length {len}"));
+            }
+
+            // Then read rest of packet
+            let packet_slice = buffer
+                .get_mut(SMBUS_HEADER_SZ..SMBUS_HEADER_SZ + len)
+                .ok_or_else(|| eyre!("Serial error: Response does not fit in buffer"))?;
+            port.read_exact(packet_slice)
+                .map_err(|e| eyre!("Serial error: {e:?}"))?;
+
+            let flags = buffer[MCTP_FLAGS_IDX];
+
+            // If this is a SOM packet, skip ODP header (we don't use it) and grab the command code/discriminant
+            let payload_start_idx = if flags & 0x80 != 0 {
+                cmd_code = u16::from_be_bytes(
+                    buffer[HEADER_SZ..HEADER_SZ + CMD_CODE_SZ]
+                        .try_into()
+                        .expect("CMD_CODE_SZ must equal 2"),
+                );
+                HEADER_SZ + CMD_CODE_SZ
+            } else {
+                SMBUS_HEADER_SZ + MCTP_HEADER_SZ
+            };
+
+            // Finally copy the packet into our buffer used for storing the entire response at the appropriate offset
+            let data_slice = &buffer[payload_start_idx..SMBUS_HEADER_SZ + len];
+            let len = data_slice.len();
+            response_buf[offset..offset + len].copy_from_slice(data_slice);
+            offset += len;
+
+            // If this is EOM packet, we are done
+            if flags & 0x40 != 0 {
+                break;
+            }
+        }
+
+        RESP::deserialize(cmd_code, &response_buf).map_err(|e| eyre!("Deserialization error: {e:?}"))
+    }
+
+    fn thermal_get_var(&self, guid: uuid::Uuid) -> Result<f64> {
+        let request = ThermalRequest::ThermalGetVarRequest {
+            instance_id: SENSOR_INSTANCE,
+            len: THERMAL_VAR_LEN,
+            var_uuid: guid.to_bytes_le(),
+        };
+        let response = self.send(Destination::Thermal, request)?;
+
+        if let ThermalResponse::ThermalGetVarResponse { val } = response {
+            Ok(val as f64)
+        } else {
+            Err(eyre!("GET_VAR received wrong response"))
+        }
+    }
+
+    fn thermal_set_var(&self, guid: uuid::Uuid, raw: u32) -> Result<()> {
+        let request = ThermalRequest::ThermalSetVarRequest {
+            instance_id: SENSOR_INSTANCE,
+            len: THERMAL_VAR_LEN,
+            var_uuid: guid.to_bytes_le(),
+            set_var: raw,
+        };
+        let response = self.send(Destination::Thermal, request)?;
+
+        if let ThermalResponse::ThermalSetVarResponse = response {
+            Ok(())
+        } else {
+            Err(eyre!("SET_VAR received wrong response"))
+        }
+    }
+}
+
+impl Source for Serial {
+    fn get_temperature(&self) -> Result<f64> {
+        let request = ThermalRequest::ThermalGetTmpRequest {
+            instance_id: SENSOR_INSTANCE,
+        };
+        let response = self.send(Destination::Thermal, request)?;
+
+        if let ThermalResponse::ThermalGetTmpResponse { temperature } = response {
+            Ok(common::dk_to_c(temperature))
+        } else {
+            Err(eyre!("GET_TMP received wrong response"))
+        }
+    }
+
+    fn get_rpm(&self) -> Result<f64> {
+        self.thermal_get_var(common::guid::FAN_CURRENT_RPM)
+    }
+
+    fn get_min_rpm(&self) -> Result<f64> {
+        self.thermal_get_var(common::guid::FAN_MIN_RPM)
+    }
+
+    fn get_max_rpm(&self) -> Result<f64> {
+        self.thermal_get_var(common::guid::FAN_MAX_RPM)
+    }
+
+    fn get_threshold(&self, threshold: Threshold) -> Result<f64> {
+        let raw = match threshold {
+            Threshold::On => self.thermal_get_var(common::guid::FAN_ON_TEMP),
+            Threshold::Ramping => self.thermal_get_var(common::guid::FAN_RAMP_TEMP),
+            Threshold::Max => self.thermal_get_var(common::guid::FAN_MAX_TEMP),
+        }?;
+        Ok(common::dk_to_c(raw as u32))
+    }
+
+    fn set_rpm(&self, rpm: f64) -> Result<()> {
+        self.thermal_set_var(common::guid::FAN_CURRENT_RPM, rpm as u32)
+    }
+
+    fn get_bst(&self) -> Result<BstReturn> {
+        let request = AcpiBatteryRequest::BatteryGetBstRequest {
+            battery_id: BATTERY_INSTANCE,
+        };
+        let response = self.send(Destination::Battery, request)?;
+
+        if let AcpiBatteryResponse::BatteryGetBstResponse { bst } = response {
+            Ok(bst)
+        } else {
+            Err(eyre!("GET_BST received wrong response"))
+        }
+    }
+
+    fn get_bix(&self) -> Result<BixFixedStrings> {
+        let request = AcpiBatteryRequest::BatteryGetBixRequest {
+            battery_id: BATTERY_INSTANCE,
+        };
+        let response = self.send(Destination::Battery, request)?;
+
+        if let AcpiBatteryResponse::BatteryGetBixResponse { bix } = response {
+            Ok(bix)
+        } else {
+            Err(eyre!("GET_BIX received wrong response"))
+        }
+    }
+
+    fn set_btp(&self, trip_point: u32) -> Result<()> {
+        let request = AcpiBatteryRequest::BatterySetBtpRequest {
+            battery_id: BATTERY_INSTANCE,
+            btp: Btp { trip_point },
+        };
+        let response = self.send(Destination::Battery, request)?;
+
+        if matches!(response, AcpiBatteryResponse::BatterySetBtpResponse {}) {
+            Ok(())
+        } else {
+            Err(eyre!("SET_BTP received wrong response"))
+        }
+    }
+}
+
+impl RtcSource for Serial {
+    fn get_capabilities(&self) -> Result<TimeAlarmDeviceCapabilities> {
+        let request = AcpiTimeAlarmRequest::GetCapabilities;
+        let response = self.send(Destination::TimeAlarm, request)?;
+
+        if let AcpiTimeAlarmResponse::Capabilities(capabilities) = response {
+            Ok(capabilities)
+        } else {
+            Err(eyre!("GET_CAPABILITIES received wrong response"))
+        }
+    }
+
+    fn get_real_time(&self) -> Result<AcpiTimestamp> {
+        let request = AcpiTimeAlarmRequest::GetRealTime;
+        let response = self.send(Destination::TimeAlarm, request)?;
+
+        if let AcpiTimeAlarmResponse::RealTime(timestamp) = response {
+            Ok(timestamp)
+        } else {
+            Err(eyre!("GET_REAL_TIME received wrong response"))
+        }
+    }
+
+    fn get_wake_status(&self, timer_id: AcpiTimerId) -> Result<TimerStatus> {
+        let request = AcpiTimeAlarmRequest::GetWakeStatus(timer_id);
+        let response = self.send(Destination::TimeAlarm, request)?;
+
+        if let AcpiTimeAlarmResponse::TimerStatus(status) = response {
+            Ok(status)
+        } else {
+            Err(eyre!("GET_WAKE_STATUS received wrong response"))
+        }
+    }
+
+    fn get_expired_timer_wake_policy(&self, timer_id: AcpiTimerId) -> Result<AlarmExpiredWakePolicy> {
+        let request = AcpiTimeAlarmRequest::GetExpiredTimerPolicy(timer_id);
+        let response = self.send(Destination::TimeAlarm, request)?;
+
+        if let AcpiTimeAlarmResponse::WakePolicy(policy) = response {
+            Ok(policy)
+        } else {
+            Err(eyre!("GET_TIP received wrong response"))
+        }
+    }
+
+    fn get_timer_value(&self, timer_id: AcpiTimerId) -> Result<AlarmTimerSeconds> {
+        let request = AcpiTimeAlarmRequest::GetTimerValue(timer_id);
+        let response = self.send(Destination::TimeAlarm, request)?;
+
+        if let AcpiTimeAlarmResponse::TimerSeconds(seconds) = response {
+            Ok(seconds)
+        } else {
+            Err(eyre!("GET_TIV received wrong response"))
+        }
+    }
+}

--- a/rust/src/widgets/battery.rs
+++ b/rust/src/widgets/battery.rs
@@ -151,7 +151,7 @@ impl StatefulWidget for Battery {
             .render(tip_area, buf);
 
         if state.is_charging {
-            Bolt::default().render(battery_area, buf)
+            Bolt.render(battery_area, buf)
         }
     }
 }


### PR DESCRIPTION
This PR does a few things:

- Adds serial as a `Source`, which allows the app to talk directly to a dev platform in user-space (over a COM port for example). Can be useful for testing services without needing to worry about FFA and whatnot.
- Fixes some clippy warnings introduced from needing to bump MSRV
- Some minor refactoring to use the message structs defined by the crates in embedded-services

Tested this on the `dev-imxrt` platform and works pretty well.

Can run with:
`cargo run --release --features serial <COM#> none [baud]`

Baud rate is an optional argument and can be omitted since I have it set to default to 115200 which the dev platforms use.