### PR TITLE
Update CODEOWNERS

### DIFF
--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -1,1 +1,1 @@
-* @OpenDevicePartnership/ec-code-owners @philgweber @williampMSFT
+* @OpenDevicePartnership/ec-platform-team


### PR DESCRIPTION
This pull request updates the `CODEOWNERS` file to assign ownership of the entire codebase to the `@OpenDevicePartnership/ec-platform-team` group instead of the previous individual owners.